### PR TITLE
Compress round diagram should match the slide picture

### DIFF
--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/BitOpLabel.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/BitOpLabel.java
@@ -31,7 +31,7 @@ public class BitOpLabel extends JLabel implements MouseListener {
     /**
      * The pixel width and height of this component.
      */
-    public static final int SIZE = 46;
+    public static final int SIZE = 48;
     
     public static final int HALF_SIZE = SIZE / 2;
     
@@ -55,7 +55,7 @@ public class BitOpLabel extends JLabel implements MouseListener {
     /**
      * The background of this label is pinkish when not highlighted.
      */
-    private static final Color NORMAL_BACKGROUND = new Color(150, 229, 247);
+    private static final Color NORMAL_BACKGROUND = new Color(230,230,250);
     
     /**
      * The background of this label is a light yellow when highlighted.

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
@@ -123,6 +123,16 @@ public class CompressionCanvasView extends UserRequestView {
             drawArrowLine(g, x, y -60, x, p.y, 6, 6);
         }
         
+        // Lines going out of working variables at the bottom
+        for (int i = 0; i < inWorkingVars.length; i++) {
+            p = outWorkingVars[i].getLocation();
+
+            x = p.x + WorkingVarLabel.HALF_SIZE;
+            y = p.y + WorkingVarLabel.SIZE * 2;
+
+            drawArrowLine(g, x, y - 60, x, y, 6, 6);
+        }
+        
         // hide the 'd' to 'e' connection behind the modulo addition
         modAdditions[0].repaint();
         

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
@@ -267,6 +267,21 @@ public class CompressionCanvasView extends UserRequestView {
         y = p.y + AddMod256Label.HALF_SIZE;
         drawArrowLine(g, x, y, x2, y, 6, 6);
         
+        // Arrow from Sigma0 to modAdditions[4]
+        p = sigma0Label.getLocation();
+        x = p.x + BitOpLabel.SIZE;
+        y = p.y + BitOpLabel.HALF_SIZE;
+        p = modAdditions[4].getLocation();
+        x2 = p.x;
+        drawArrowLine(g, x, y, x2, y, 6, 6);
+        
+        // Arrow from modAdditions[4] to modAdditions[5]
+        p = modAdditions[4].getLocation();
+        x = p.x + AddMod256Label.SIZE;
+        y = p.y + AddMod256Label.HALF_SIZE;
+        p = modAdditions[5].getLocation();
+        x2 = p.x;
+        drawArrowLine(g, x, y, x2, y, 6, 6);
     }
 
     /**
@@ -392,6 +407,14 @@ public class CompressionCanvasView extends UserRequestView {
         x = sigma0Label.getLocation().x + BitOpLabel.HALF_SIZE - AddMod256Label.HALF_SIZE + 150;
         modAdditions[5].setLocation(new Point(x, y));
         add(modAdditions[5]);
+        
+        // Temporary Variable 2 location between fourth and fifth mod addition
+        x = modAdditions[4].getLocation().x;
+        y = modAdditions[4].getLocation().y;
+        x += AddMod256Label.SIZE;
+        y += AddMod256Label.HALF_SIZE - 10;
+        temp2Label.setLocation(x, y);
+        add(temp2Label);
     }
 
     /**

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
@@ -17,6 +17,7 @@ import edu.regis.shatu.model.aol.NewExampleRequest;
 import java.awt.Color;
 import java.awt.Graphics;
 import java.awt.Point;
+import javax.swing.JLabel;
 
 /**
  * Displays a single round of the SHA-256 compression algorithm.
@@ -71,6 +72,8 @@ public class CompressionCanvasView extends UserRequestView {
     private BitOpLabel sigma1Label;
     private BitOpLabel chLabel;
     private BitOpLabel majLabel;
+    private JLabel wLabel = new JLabel();
+    private JLabel kLabel = new JLabel();
 
     public CompressionCanvasView() {
         setLayout(null);
@@ -106,6 +109,18 @@ public class CompressionCanvasView extends UserRequestView {
             p = outWorkingVars[i + 1].getLocation();
             x2 = p.x + WorkingVarLabel.HALF_SIZE;
             drawArrowLine(g, x, y + 300, x2, p.y, 6, 6);
+        }
+        
+        // Lines going into working variables
+        for (int i = 0; i < inWorkingVars.length; i++) {
+            p = inWorkingVars[i].getLocation();
+
+            x = p.x + WorkingVarLabel.HALF_SIZE;
+            y = p.y + WorkingVarLabel.SIZE;
+
+            g.drawLine(x, y, x, y - 60);
+            
+            drawArrowLine(g, x, y -60, x, p.y, 6, 6);
         }
         
         // hide the 'd' to 'e' connection behind the modulo addition
@@ -184,8 +199,8 @@ public class CompressionCanvasView extends UserRequestView {
 
         sigma1Label = new BitOpLabel("s1");
         sigma0Label = new BitOpLabel("s0");
-        chLabel = new BitOpLabel("ch");
-        majLabel = new BitOpLabel("maj");
+        chLabel = new BitOpLabel("Ch");
+        majLabel = new BitOpLabel("Maj");
 
     }
 

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
@@ -15,9 +15,9 @@ package edu.regis.shatu.view;
 import edu.regis.shatu.model.StepCompletion;
 import edu.regis.shatu.model.aol.NewExampleRequest;
 import java.awt.Color;
+import java.awt.Font;
 import java.awt.Graphics;
 import java.awt.Point;
-import javax.swing.JLabel;
 
 /**
  * Displays a single round of the SHA-256 compression algorithm.
@@ -312,21 +312,32 @@ public class CompressionCanvasView extends UserRequestView {
         for (int i = 0; i < modAdditions.length; i++) {
             modAdditions[i] = new AddMod256Label();
         }
-
-        sigma1Label = new BitOpLabel("s1");
-        sigma0Label = new BitOpLabel("s0");
+        int sigma = 931;
+        sigma1Label = new BitOpLabel((char)sigma + "\u2081");
+        sigma0Label = new BitOpLabel((char) sigma + "\u2080");
         chLabel = new BitOpLabel("Ch");
         majLabel = new BitOpLabel("Maj");
         
-        wLabel = new VariableLabel("Wt");
-        kLabel = new VariableLabel("Kt");
+        sigma1Label.setFont(new Font("", Font.PLAIN, 16));
+        sigma0Label.setFont(new Font("", Font.PLAIN, 16));
         
-        temp1Label = new VariableLabel("T1");
-        temp2Label = new VariableLabel("T2");
-
+        wLabel = new VariableLabel("W\u209C");
+        kLabel = new VariableLabel("K\u209C");
+        
+        
+        wLabel.setFont(new Font("", Font.PLAIN, 16));
+        kLabel.setFont(new Font("", Font.PLAIN, 16));
+        
+        temp1Label = new VariableLabel("T\u2081");
+        temp2Label = new VariableLabel("T\u2082");
+        
+        temp1Label.setFont(new Font("", Font.PLAIN, 16));
+        temp2Label.setFont(new Font("", Font.PLAIN, 16));
     }
 
     private void layoutComponents() {
+        Color white = new Color(255,255,255);
+        setBackground(white);
         Point p;
         int x, y;
         
@@ -383,15 +394,15 @@ public class CompressionCanvasView extends UserRequestView {
         x = modAdditions[2].getLocation().x;
         y = modAdditions[2].getLocation().y;
         x -= VariableLabel.HALF_SIZE - 10;
-        y -= VariableLabel.SIZE + 40;
+        y -= VariableLabel.SIZE + 20;
         wLabel.setLocation(x, y);
         add(wLabel);
         
         // K input location
         x = modAdditions[2].getLocation().x;
         y = modAdditions[2].getLocation().y;
-        x += VariableLabel.SIZE + 10;
-        y -= VariableLabel.HALF_SIZE - 10;
+        x += VariableLabel.SIZE;
+        y -= VariableLabel.HALF_SIZE;
         kLabel.setLocation(x, y);
         add(kLabel);
         

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
@@ -282,6 +282,16 @@ public class CompressionCanvasView extends UserRequestView {
         p = modAdditions[5].getLocation();
         x2 = p.x;
         drawArrowLine(g, x, y, x2, y, 6, 6);
+        
+        // Arrow from Maj to modAdditions[4]
+        p = majLabel.getLocation();
+        x = p.x + BitOpLabel.SIZE;
+        y = p.y + BitOpLabel.HALF_SIZE;
+        p = modAdditions[4].getLocation();
+        x2 = p.x + AddMod256Label.HALF_SIZE;
+        y2 = p.y;
+        g.drawLine(x, y, x2, y);
+        drawArrowLine(g, x2, y, x2, y2, 6, 6);
     }
 
     /**

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
@@ -193,6 +193,13 @@ public class CompressionCanvasView extends UserRequestView {
         y = p2.y + BitOpLabel.SIZE - 5;
         drawArrowLine(g, x, y, p2.x, y, 6, 6);
         
+        // The arrow from 'a' line to Sigma0
+        p = inWorkingVars[0].getLocation();
+        p2 = sigma0Label.getLocation();
+        x = p.x + WorkingVarLabel.HALF_SIZE;
+        y = p2.y + BitOpLabel.HALF_SIZE;
+        drawArrowLine(g, x, y, p2.x, y, 6, 6);
+        
         // Arrow from Ch to modAdditions[1]
         p = chLabel.getLocation();
         x = p.x + BitOpLabel.SIZE;

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
@@ -74,6 +74,8 @@ public class CompressionCanvasView extends UserRequestView {
     private BitOpLabel majLabel;
     private VariableLabel wLabel;
     private VariableLabel kLabel;
+    private VariableLabel temp1Label;
+    private VariableLabel temp2Label;
 
     public CompressionCanvasView() {
         setLayout(null);
@@ -256,6 +258,15 @@ public class CompressionCanvasView extends UserRequestView {
         y = p.y + AddMod256Label.HALF_SIZE;
         drawArrowLine(g, x, y, x - 40, y, 6, 6);
         
+        
+        // Arrow from Temporary Variable 1 to modAdditions[0]
+        p = modAdditions[3].getLocation();
+        x = p.x + AddMod256Label.HALF_SIZE;
+        p = modAdditions[0].getLocation();
+        x2 = p.x + AddMod256Label.SIZE;
+        y = p.y + AddMod256Label.HALF_SIZE;
+        drawArrowLine(g, x, y, x2, y, 6, 6);
+        
     }
 
     /**
@@ -284,6 +295,9 @@ public class CompressionCanvasView extends UserRequestView {
         
         wLabel = new VariableLabel("Wt");
         kLabel = new VariableLabel("Kt");
+        
+        temp1Label = new VariableLabel("T1");
+        temp2Label = new VariableLabel("T2");
 
     }
 
@@ -356,11 +370,18 @@ public class CompressionCanvasView extends UserRequestView {
         kLabel.setLocation(x, y);
         add(kLabel);
         
-        // Has Sigma1 inputs and centered on it
+        // Third mod addition has Sigma1 inputs and centered on it
         x = sigma1Label.getLocation().x + BitOpLabel.HALF_SIZE - AddMod256Label.HALF_SIZE + 150;
         y = sigma1Label.getLocation().y + BitOpLabel.HALF_SIZE - AddMod256Label.HALF_SIZE;
         modAdditions[3].setLocation(new Point(x, y));
         add(modAdditions[3]);
+        
+        // Temporary Variable 1 location under third mod addition
+        x = modAdditions[3].getLocation().x;
+        y = modAdditions[0].getLocation().y;
+        y -= AddMod256Label.SIZE;
+        temp1Label.setLocation(x, y);
+        add(temp1Label);
         
         // Has input from sigma0 Centered on Sigma0
         x = sigma0Label.getLocation().x + BitOpLabel.HALF_SIZE - AddMod256Label.HALF_SIZE + 75;

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
@@ -72,8 +72,8 @@ public class CompressionCanvasView extends UserRequestView {
     private BitOpLabel sigma1Label;
     private BitOpLabel chLabel;
     private BitOpLabel majLabel;
-    private JLabel wLabel = new JLabel();
-    private JLabel kLabel = new JLabel();
+    private VariableLabel wLabel;
+    private VariableLabel kLabel;
 
     public CompressionCanvasView() {
         setLayout(null);
@@ -187,8 +187,6 @@ public class CompressionCanvasView extends UserRequestView {
         p = modAdditions[2].getLocation();
         x = p.x + 60;
         y = p.y + AddMod256Label.HALF_SIZE;
-        //x2 = p.x + AddMod256Label.HALF_SIZE;
-        //g.drawLine(x, y, x - 40, y);
         drawArrowLine(g, x, y, x - 40, y, 6, 6);
         
     }
@@ -216,6 +214,9 @@ public class CompressionCanvasView extends UserRequestView {
         sigma0Label = new BitOpLabel("s0");
         chLabel = new BitOpLabel("Ch");
         majLabel = new BitOpLabel("Maj");
+        
+        wLabel = new VariableLabel("Wt");
+        kLabel = new VariableLabel("Kt");
 
     }
 
@@ -271,6 +272,22 @@ public class CompressionCanvasView extends UserRequestView {
         // Has W and K inputs
         modAdditions[2].setLocation(new Point(x+ AddMod256Label.SIZE + 100, y));
         add(modAdditions[2]);
+        
+        // W input location
+        x = modAdditions[2].getLocation().x;
+        y = modAdditions[2].getLocation().y;
+        x -= VariableLabel.HALF_SIZE - 10;
+        y -= VariableLabel.SIZE + 40;
+        wLabel.setLocation(x, y);
+        add(wLabel);
+        
+        // K input location
+        x = modAdditions[2].getLocation().x;
+        y = modAdditions[2].getLocation().y;
+        x += VariableLabel.SIZE + 10;
+        y -= VariableLabel.HALF_SIZE - 10;
+        kLabel.setLocation(x, y);
+        add(kLabel);
         
         // Has Sigma1 inputs and centered on it
         x = sigma1Label.getLocation().x + BitOpLabel.HALF_SIZE - AddMod256Label.HALF_SIZE + 150;

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
@@ -165,6 +165,13 @@ public class CompressionCanvasView extends UserRequestView {
         y = p2.y + BitOpLabel.SIZE - 5;
         drawArrowLine(g, x, y, p2.x, y, 6, 6);
         
+        // The arrow from 'e' line to Sigma1
+        p = inWorkingVars[4].getLocation();
+        p2 = sigma1Label.getLocation();
+        x = p.x + WorkingVarLabel.HALF_SIZE;
+        y = p2.y + BitOpLabel.HALF_SIZE;
+        drawArrowLine(g, x, y, p2.x, y, 6, 6);
+        
         // Arrow from Ch to modAdditions[1]
         p = chLabel.getLocation();
         x = p.x + BitOpLabel.SIZE;

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
@@ -176,6 +176,13 @@ public class CompressionCanvasView extends UserRequestView {
         
         drawArrowLine(g, x2, y2, x2, p.y , 6, 6);
         
+        // Arrow from Wt to modAdditions[2]
+        p = modAdditions[2].getLocation();
+        x = p.x + AddMod256Label.HALF_SIZE;
+        y = p.y;
+        g.drawLine(x, y, x, y - 40);
+        drawArrowLine(g, x, y -40, x, p.y, 6, 6);
+        
     }
 
     /**

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
@@ -172,6 +172,27 @@ public class CompressionCanvasView extends UserRequestView {
         y = p2.y + BitOpLabel.HALF_SIZE;
         drawArrowLine(g, x, y, p2.x, y, 6, 6);
         
+        // The arrow from 'a' line to Maj
+        p = inWorkingVars[0].getLocation();
+        p2 = majLabel.getLocation();
+        x = p.x + WorkingVarLabel.HALF_SIZE;
+        y = p2.y + 5;
+        drawArrowLine(g, x, y, p2.x, y, 6, 6);
+        
+        // The arrow from 'b' line to Maj
+        p = inWorkingVars[1].getLocation();
+        p2 = majLabel.getLocation();
+        x = p.x + WorkingVarLabel.HALF_SIZE;
+        y = p2.y + BitOpLabel.HALF_SIZE;
+        drawArrowLine(g, x, y, p2.x, y, 6, 6);
+        
+        // The arrow from 'c' line to Maj
+        p = inWorkingVars[2].getLocation();
+        p2 = majLabel.getLocation();
+        x = p.x + WorkingVarLabel.HALF_SIZE;
+        y = p2.y + BitOpLabel.SIZE - 5;
+        drawArrowLine(g, x, y, p2.x, y, 6, 6);
+        
         // Arrow from Ch to modAdditions[1]
         p = chLabel.getLocation();
         x = p.x + BitOpLabel.SIZE;

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
@@ -93,6 +93,7 @@ public class CompressionCanvasView extends UserRequestView {
         super.paintComponent(g);
         
         Point p;
+        Point p2;
         int x, y, x2, y2;
 
         this.setForeground(Color.BLACK);
@@ -142,6 +143,27 @@ public class CompressionCanvasView extends UserRequestView {
         y = p.y + WorkingVarLabel.SIZE;
         p = modAdditions[1].getLocation();
         drawArrowLine(g, x, y, p.x, p.y, 6, 6);
+        
+        // The arrow from 'e' line to Ch
+        p = inWorkingVars[4].getLocation();
+        p2 = chLabel.getLocation();
+        x = p.x + WorkingVarLabel.HALF_SIZE;
+        y = p2.y + 5;
+        drawArrowLine(g, x, y, p2.x, y, 6, 6);
+        
+        // The arrow from 'f' line to Ch
+        p = inWorkingVars[5].getLocation();
+        p2 = chLabel.getLocation();
+        x = p.x + WorkingVarLabel.HALF_SIZE;
+        y = p2.y + BitOpLabel.HALF_SIZE;
+        drawArrowLine(g, x, y, p2.x, y, 6, 6);
+        
+        // The arrow from 'g' line to Ch
+        p = inWorkingVars[6].getLocation();
+        p2 = chLabel.getLocation();
+        x = p.x + WorkingVarLabel.HALF_SIZE;
+        y = p2.y + BitOpLabel.SIZE - 5;
+        drawArrowLine(g, x, y, p2.x, y, 6, 6);
         
         // Arrow from Ch to modAdditions[1]
         p = chLabel.getLocation();

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
@@ -183,6 +183,14 @@ public class CompressionCanvasView extends UserRequestView {
         g.drawLine(x, y, x, y - 40);
         drawArrowLine(g, x, y -40, x, p.y, 6, 6);
         
+        // Arrow from Kt to modAdditions[2]
+        p = modAdditions[2].getLocation();
+        x = p.x + 60;
+        y = p.y + AddMod256Label.HALF_SIZE;
+        //x2 = p.x + AddMod256Label.HALF_SIZE;
+        //g.drawLine(x, y, x - 40, y);
+        drawArrowLine(g, x, y, x - 40, y, 6, 6);
+        
     }
 
     /**

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/VariableLabel.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/VariableLabel.java
@@ -87,7 +87,7 @@ public class VariableLabel extends JLabel implements MouseListener {
 
         Dimension d = new Dimension(SIZE, SIZE); // Determined empirically
 
-        setOpaque(true);
+        setOpaque(false);
         //setBackground(NORMAL_BACKGROUND);
         //setBorder(NORMAL_BORDER);
         setMinimumSize(d);

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/VariableLabel.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/VariableLabel.java
@@ -84,9 +84,9 @@ public class VariableLabel extends JLabel implements MouseListener {
         super(text, SwingConstants.CENTER);
         
         isSelected = false;
-
+        
         Dimension d = new Dimension(SIZE, SIZE); // Determined empirically
-
+        
         setOpaque(false);
         //setBackground(NORMAL_BACKGROUND);
         //setBorder(NORMAL_BORDER);

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/VariableLabel.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/VariableLabel.java
@@ -1,0 +1,150 @@
+/*
+ * SHATU: SHA-256 Tutor
+ * 
+ *  (C) Johanna & Richard Blumenthal, All rights reserved
+ * 
+ *  Unauthorized use, duplication or distribution without the authors'
+ *  permission is strictly prohibted.
+ * 
+ *  Unless required by applicable law or agreed to in writing, this
+ *  software is distributed on an "AS IS" basis without warranties
+ *  or conditions of any kind, either expressed or implied.
+ */
+package edu.regis.shatu.view;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import javax.swing.BorderFactory;
+import javax.swing.JLabel;
+import javax.swing.SwingConstants;
+import javax.swing.border.Border;
+import javax.swing.border.CompoundBorder;
+import javax.swing.border.EmptyBorder;
+
+/**
+ *
+ * @author Amanda Roskelley
+ */
+public class VariableLabel extends JLabel implements MouseListener {
+    /**
+     * The pixel width and height of this component.
+     */
+    public static final int SIZE = 48;
+    
+    public static final int HALF_SIZE = SIZE / 2;
+    
+        /**
+     * This empty border serves as an inset so the text doesn't touch the edges.
+     */
+    private static final Border EMPTY_BORDER = new EmptyBorder(5, 10, 5, 10);
+
+    /**
+     * A simple black line surrounds this label when not highlighted.
+     */
+    private static final Border NORMAL_BORDER
+            = new CompoundBorder(BorderFactory.createLineBorder(Color.BLUE), EMPTY_BORDER);
+
+    /**
+     * A red line with thickness two surrounds this label when highlighted.
+     */
+    private static final Border HIGHLIGHT_BORDER
+            = new CompoundBorder(BorderFactory.createLineBorder(Color.RED, 2), EMPTY_BORDER);
+    
+    /**
+     * The background of this label is white when not highlighted.
+     */
+    private static final Color NORMAL_BACKGROUND = new Color(255,255,255);
+    
+    /**
+     * The background of this label is a light yellow when highlighted.
+     */
+    private static final Color HIGHLIGHT_BACKGROUND = new Color(210,248,210);
+    
+    /**
+     * The background of this label when selected.
+     */
+    private static final Color SELECTED_BACKGROUND = new Color(212,235,242);
+    
+    /**
+     * The view that is displayed when this label is selected.
+     */
+    private StepSelection stepSelection;
+    
+    private boolean isSelected;
+
+    /**
+     * Initialize this label with the given text and a size that was determined
+     * empirically.
+     * 
+     * @param text the text of this label
+     */
+    public VariableLabel(String text) {
+        super(text, SwingConstants.CENTER);
+        
+        isSelected = false;
+
+        Dimension d = new Dimension(SIZE, SIZE); // Determined empirically
+
+        setOpaque(true);
+        //setBackground(NORMAL_BACKGROUND);
+        //setBorder(NORMAL_BORDER);
+        setMinimumSize(d);
+        setSize(d);
+
+        this.addMouseListener(this);
+    }
+    
+    public void select() {
+        GuiController.instance().getStepSelectorView().displayStep(stepSelection);
+        isSelected = true;
+        //setBackground(SELECTED_BACKGROUND);
+    }
+    
+    public void deselect() {
+        isSelected = false;
+       // setBackground(NORMAL_BACKGROUND);
+    }
+
+    @Override
+    public void mouseClicked(MouseEvent evt) {
+        if (!isSelected) {
+            select();
+        }
+    }
+
+    @Override
+    public void mousePressed(MouseEvent e) {
+    }
+
+    @Override
+    public void mouseReleased(MouseEvent e) {
+    }
+
+    /**
+     * When the mouse enters this label, highlight it.
+     * 
+     * @param e ignored
+     */
+    @Override
+    public void mouseEntered(MouseEvent e) {
+        if (!isSelected) {
+            //setBorder(HIGHLIGHT_BORDER);
+            //setBackground(HIGHLIGHT_BACKGROUND);
+        }
+    }
+
+    /**
+     * When the mouse exits this label, unhighlight it.
+     * 
+     * @param e ignored
+     */
+    @Override
+    public void mouseExited(MouseEvent e) {
+        if (!isSelected) {
+            //setBorder(NORMAL_BORDER);
+            //setBackground(NORMAL_BACKGROUND);
+        }
+    }
+}


### PR DESCRIPTION
"SHAT-118: As we decide exactly what the interaction with this picture should be for our users, at a bare minimum it needs to match the diagram from the slides. "

Here is the slide picture:
<img width="727" alt="Screenshot 2024-10-15 at 1 00 37 PM" src="https://github.com/user-attachments/assets/ef474a27-c8a5-4839-a696-9d3a6361ce23">

And here is screenshot of the compress round diagram now:
<img width="1231" alt="Screenshot 2024-10-15 at 2 06 42 PM" src="https://github.com/user-attachments/assets/7d391d32-edad-485d-9f26-784da458d393">
