### PR TITLE
Add Two Bits: Cleaned Up Code

### DIFF
--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/AddTwoBitView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/AddTwoBitView.java
@@ -334,8 +334,6 @@ public class AddTwoBitView extends UserRequestView implements ActionListener, Ke
         
         BitOpStep example = gson.fromJson(step.getData(), BitOpStep.class);
         
-        System.out.println("AddTwoBitView update display called");
-        
         try {
             binary1 = example.getExample().getOperand1();
             binary2 = example.getExample().getOperand2();
@@ -345,14 +343,8 @@ public class AddTwoBitView extends UserRequestView implements ActionListener, Ke
             System.out.println("Example is empty.");
         }
         
-        
         stringLabel1.setText("binary number1: " + binary1);
         stringLabel2.setText("binary number2: " + binary2);
-        //this is just for testing purposes and can be removed after it is verified that the check button works
-        stringLabel4.setText("the result is: " + result);
-
-            stringLabel1.setText("binary number1: " + binary1);
-            stringLabel2.setText("binary number2: " + binary2);
         }
     }    
 }


### PR DESCRIPTION
SHAT-153 Add Two Bits: Clean Up and Correct Error
-Clean up the Add Two n Bits so that the result is not being displayed to the user (only where developers can see it).
-Correct the error that is occurring when the answer is incorrect.

I cleaned up the code so the answer was no longer displayed to the user, only the developer. I did not find any error when the answer is incorrect (here is a screen recording of that).


https://github.com/user-attachments/assets/2f2cf620-c7f5-43f8-ad5a-d8d30a3d7720

