### PR TITLE
Accessibility Testing (Enter Key/Mouse Click for Check Button)

### DIFF
--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/AddTwoBitView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/AddTwoBitView.java
@@ -19,6 +19,7 @@ import edu.regis.shatu.model.StepCompletion;
 import edu.regis.shatu.model.aol.BitOpStep;
 import edu.regis.shatu.model.aol.ExampleType;
 import edu.regis.shatu.model.aol.NewExampleRequest;
+import edu.regis.shatu.view.act.HintAction;
 import edu.regis.shatu.view.act.NewExampleAction;
 import edu.regis.shatu.view.act.StepCompletionAction;
 import java.awt.GridBagConstraints;
@@ -220,7 +221,7 @@ public class AddTwoBitView extends UserRequestView implements ActionListener, Ke
         if (e.getKeyCode() == KeyEvent.VK_ENTER && answerField.getText().equals("")) {
             JOptionPane.showMessageDialog(this, "Please provide an answer");
         } else if (e.getKeyCode() == KeyEvent.VK_ENTER) {
-            verifyAnswer();
+            checkButton.doClick();
         }
     }
 
@@ -260,8 +261,8 @@ public class AddTwoBitView extends UserRequestView implements ActionListener, Ke
      */
     private void onNextHint() {
         JOptionPane.showMessageDialog(this, "Hint");
-    }
-
+        }
+       
     /**
      * Handles the action for the Check button.
      */

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/ChoiceFunctionView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/ChoiceFunctionView.java
@@ -470,7 +470,7 @@ public class ChoiceFunctionView extends UserRequestView implements ActionListene
         if (e.getKeyCode() == KeyEvent.VK_ENTER && responseTextArea.getText().equals("")) {
             feedbackTextArea.setText("Please provide an answer");
         } else if (e.getKeyCode() == KeyEvent.VK_ENTER) {
-            verifyAnswer();
+            checkButton.doClick();
         }
     }
 

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/ExclusiveOrView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/ExclusiveOrView.java
@@ -475,7 +475,7 @@ public class ExclusiveOrView extends UserRequestView implements ActionListener, 
         if (e.getKeyCode() == KeyEvent.VK_ENTER && responseTextArea.getText().equals("")) {
             JOptionPane.showMessageDialog(this, "Please provide an answer");
         } else if (e.getKeyCode() == KeyEvent.VK_ENTER) {
-            verifyAnswer();
+            checkButton.doClick();
         }
     }
 

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/MajFunctionView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/MajFunctionView.java
@@ -416,7 +416,7 @@ public class MajFunctionView extends UserRequestView implements ActionListener, 
         if (e.getKeyCode() == KeyEvent.VK_ENTER && responseTextArea.getText().equals("")) {
             JOptionPane.showMessageDialog(this, "Please provide an answer");
         } else if (e.getKeyCode() == KeyEvent.VK_ENTER) {
-            verifyAnswer();
+            checkButton.doClick();
         }
     }
 

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/RotateView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/RotateView.java
@@ -236,7 +236,7 @@ public class RotateView extends UserRequestView implements ActionListener, KeyLi
         if (e.getKeyCode() == KeyEvent.VK_ENTER && answerField.getText().equals("")) {
             JOptionPane.showMessageDialog(this, "Please provide an answer");
         } else if (e.getKeyCode() == KeyEvent.VK_ENTER) {
-            //verifyAnswer(this.problemString, this.numRotations);
+            checkButton.doClick();
         }
     }
 

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/ShaOneView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/ShaOneView.java
@@ -133,7 +133,7 @@ public class ShaOneView extends UserRequestView implements ActionListener, KeyLi
         if (e.getKeyCode() == KeyEvent.VK_ENTER && answerField.getText().equals("")) {
             JOptionPane.showMessageDialog(this, "Please provide an answer");
         } else if (e.getKeyCode() == KeyEvent.VK_ENTER) {
-            verifyAnswer();
+            checkButton.doClick();
         }
     }
 

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/ShaZeroView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/ShaZeroView.java
@@ -136,7 +136,7 @@ public class ShaZeroView extends UserRequestView implements ActionListener, KeyL
         if (e.getKeyCode() == KeyEvent.VK_ENTER && answerField.getText().equals("")) {
             JOptionPane.showMessageDialog(this, "Please provide an answer");
         } else if (e.getKeyCode() == KeyEvent.VK_ENTER) {
-            verifyAnswer();
+            checkButton.doClick();
         }
     }
 

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/ShiftRightView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/ShiftRightView.java
@@ -360,6 +360,7 @@ public class ShiftRightView extends UserRequestView implements ActionListener, K
         if (e.getKeyCode() == KeyEvent.VK_ENTER && responseTextArea.getText().equals("")) {
             JOptionPane.showMessageDialog(this, "Please provide an answer");
         } else if (e.getKeyCode() == KeyEvent.VK_ENTER) {
+            checkButton.doClick();
         }
     }
 


### PR DESCRIPTION
SHAT-156 - Accessibility Testing:
-This ensures that when the user hits the Enter key on their keyboard, the check button functions the same as if the user used their mouse.

This pull request does not include all views, as some have not been implemented yet, and others are formatted differently. There is a second ticket for the accessibility in those views that will be completed in Sprint 5.  For this part, the user can hit the Enter key and it will work the same as a mouse click (Check button) in the following views: RotateNBits, ShiftRight, ExclusiveOr, Add2Bits, Choice, Majority, Sha0, Sha1. 