### PR TITLE
Accessibility (Part 2) Enter Key and Check Button

### DIFF
--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/Add1View.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/Add1View.java
@@ -36,7 +36,10 @@ import javax.swing.table.DefaultTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
 import javax.swing.BoxLayout;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 
@@ -45,7 +48,7 @@ import javax.swing.JTextField;
  * 
  * @author rickb
  */
-public class Add1View extends UserRequestView implements ActionListener {
+public class Add1View extends UserRequestView implements ActionListener, KeyListener {
     private TutoringSessionView view;
     private JTextPane descriptionTextPane;
     private JLabel questionLabel, instructionsLabel, messageLengthLabel;
@@ -233,6 +236,7 @@ public class Add1View extends UserRequestView implements ActionListener {
         responseArea = new JTextArea(3, 20);
         responseArea.setLineWrap(true); // Enable line wrapping
         responseArea.setWrapStyleWord(true); // Wrap lines at word boundaries
+        responseArea.addKeyListener(this);
         responseScrollPane = new JScrollPane(responseArea);
         responseScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED); // Enable vertical scrolling
     }
@@ -478,5 +482,23 @@ public class Add1View extends UserRequestView implements ActionListener {
         step.setStep(currentStep); // Will be sent to the tutor.
         
         return step;
+    }
+    
+    @Override
+    public void keyPressed(KeyEvent e) {
+        if (e.getKeyCode() == KeyEvent.VK_ENTER && responseArea.getText().equals("")) {
+            JOptionPane.showMessageDialog(this, "Please provide an answer");
+        } else if (e.getKeyCode() == KeyEvent.VK_ENTER) {
+            checkButton.doClick();
+        }
+    }
+
+    @Override
+    public void keyTyped(KeyEvent e) {
+
+    }
+
+    @Override
+    public void keyReleased(KeyEvent e) {
     }
 }

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/EncodeView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/EncodeView.java
@@ -36,6 +36,9 @@ import javax.swing.table.DefaultTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 
@@ -44,7 +47,7 @@ import javax.swing.JTextField;
  * 
  * @author rickb
  */
-public class EncodeView extends UserRequestView implements ActionListener {
+public class EncodeView extends UserRequestView implements ActionListener, KeyListener {
     private TutoringSessionView view;
     private JTextPane descriptionTextPane;
     private JLabel questionLabel, instructionsLabel, messageLengthLabel, setQuestionLabel;
@@ -230,6 +233,7 @@ public class EncodeView extends UserRequestView implements ActionListener {
         responseArea = new JTextArea(3, 20);
         responseArea.setLineWrap(true); // Enable line wrapping
         responseArea.setWrapStyleWord(true); // Wrap lines at word boundaries
+        responseArea.addKeyListener(this);
         responseScrollPane = new JScrollPane(responseArea);
         responseScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED); // Enable vertical scrolling
     }
@@ -513,5 +517,27 @@ public class EncodeView extends UserRequestView implements ActionListener {
         step.setStep(currentStep); // Will be sent to the tutor.
         
         return step;
+    }
+    
+    /**
+     * Handles the keyPressed event for the view.
+     *
+     * @param e The KeyEvent that occurred.
+     */
+    @Override
+    public void keyPressed(KeyEvent e) {
+        if (e.getKeyCode() == KeyEvent.VK_ENTER && responseArea.getText().equals("")) {
+            JOptionPane.showMessageDialog(this, "Please provide an answer");
+        } else if (e.getKeyCode() == KeyEvent.VK_ENTER) {
+            checkButton.doClick();
+        }
+    }
+
+    @Override
+    public void keyTyped(KeyEvent e) {
+    }
+
+    @Override
+    public void keyReleased(KeyEvent e) {
     }
 }

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/MessageLenView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/MessageLenView.java
@@ -32,7 +32,10 @@ import javax.swing.JTextPane;
 import javax.swing.JTextArea;
 import javax.swing.JScrollPane;
 import java.awt.FlowLayout;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
 import javax.swing.BoxLayout;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 
@@ -42,7 +45,7 @@ import javax.swing.JTextField;
  * 
  * @author rickb
  */
-public class MessageLenView extends UserRequestView implements ActionListener {
+public class MessageLenView extends UserRequestView implements ActionListener, KeyListener {
     private TutoringSessionView view;
     private JTextPane descriptionTextPane;
     private JLabel questionLabel, instructionsLabel, messageLengthLabel;
@@ -222,6 +225,7 @@ public class MessageLenView extends UserRequestView implements ActionListener {
         responseArea = new JTextArea(3, 20);
         responseArea.setLineWrap(true); // Enable line wrapping
         responseArea.setWrapStyleWord(true); // Wrap lines at word boundaries
+        responseArea.addKeyListener(this);
         responseScrollPane = new JScrollPane(responseArea);
         responseScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED); // Enable vertical scrolling
     }
@@ -416,5 +420,23 @@ public class MessageLenView extends UserRequestView implements ActionListener {
         step.setStep(currentStep); // Will be sent to the tutor.
         
         return step;
+    }
+    
+    @Override
+    public void keyPressed(KeyEvent e) {
+        if (e.getKeyCode() == KeyEvent.VK_ENTER && responseArea.getText().equals("")) {
+            JOptionPane.showMessageDialog(this, "Please provide an answer");
+        } else if (e.getKeyCode() == KeyEvent.VK_ENTER) {
+            checkButton.doClick();
+        }
+    }
+
+    @Override
+    public void keyTyped(KeyEvent e) {
+
+    }
+
+    @Override
+    public void keyReleased(KeyEvent e) {
     }
 }

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/Pad0View.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/Pad0View.java
@@ -36,7 +36,10 @@ import javax.swing.table.DefaultTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
 import javax.swing.BoxLayout;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 
@@ -46,7 +49,7 @@ import javax.swing.JTextField;
  * 
  * @author rickb
  */
-public class Pad0View extends UserRequestView implements ActionListener {
+public class Pad0View extends UserRequestView implements ActionListener, KeyListener {
     
     private TutoringSessionView view;
     private JTextPane descriptionTextPane;
@@ -237,6 +240,7 @@ public class Pad0View extends UserRequestView implements ActionListener {
         responseArea = new JTextArea(3, 20);
         responseArea.setLineWrap(true); // Enable line wrapping
         responseArea.setWrapStyleWord(true); // Wrap lines at word boundaries
+        responseArea.addKeyListener(this);
         responseScrollPane = new JScrollPane(responseArea);
         responseScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED); // Enable vertical scrolling
     }
@@ -474,5 +478,23 @@ public class Pad0View extends UserRequestView implements ActionListener {
         step.setStep(currentStep); // Will be sent to the tutor.
         
         return step;
+    }
+    
+    @Override
+    public void keyPressed(KeyEvent e) {
+        if (e.getKeyCode() == KeyEvent.VK_ENTER && responseArea.getText().equals("")) {
+            JOptionPane.showMessageDialog(this, "Please provide an answer");
+        } else if (e.getKeyCode() == KeyEvent.VK_ENTER) {
+            checkButton.doClick();
+        }
+    }
+
+    @Override
+    public void keyTyped(KeyEvent e) {
+
+    }
+
+    @Override
+    public void keyReleased(KeyEvent e) {
     }
 }


### PR DESCRIPTION
For SHAT-180: https://chayabasha.atlassian.net/browse/SHAT-180

Completed accessibility for the top views of the practice screen- Encode as ASCII, Add '1' bit, Pad with '0's, Add Msg Length. I added Key Listeners to these views so the user can hit the Enter key when they want to check their answer in addition to being able to click the Check Button. Note- for each of these views, the New Example button needs to be clicked first.