### PR TITLE
Add new counter label to Compress Round view

### DIFF
--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
@@ -93,6 +93,7 @@ public class CompressionCanvasView extends UserRequestView {
     private VariableLabel temp1Label;
     private VariableLabel temp2Label;
     private JButton continueButton = new JButton(StepCompletionAction.instance());
+    private CounterLabel counter;
 
     public CompressionCanvasView() {
         setLayout(null);
@@ -349,6 +350,8 @@ public class CompressionCanvasView extends UserRequestView {
         temp1Label = new VariableLabel("T\u2081");
         temp2Label = new VariableLabel("T\u2082");
         
+        counter = new CounterLabel("Round: ");
+        
         temp1Label.setFont(new Font("", Font.PLAIN, 16));
         temp2Label.setFont(new Font("", Font.PLAIN, 16));
         
@@ -362,7 +365,8 @@ public class CompressionCanvasView extends UserRequestView {
         Color white = new Color(255,255,255);
         setBackground(white);
         Point p;
-        int x, y;
+        int x, y, countX, countY;
+        
         
         for (int i = 0; i < WORKING_VARS_LEN; i++) {
             x = LEFT_INDENT + (29 * i);
@@ -374,6 +378,7 @@ public class CompressionCanvasView extends UserRequestView {
             add(outWorkingVars[i]);
         }
 
+        
         // The Bit operations Ch, Simga1, Maj, and Sigma2 are located a few 
         // pixels to the right of the last working variable 'h', which is
         // inWorkingVars[7] and below the input working variables.
@@ -387,6 +392,7 @@ public class CompressionCanvasView extends UserRequestView {
         y += WorkingVarLabel.SIZE + 40;
         sigma1Label.setLocation(new Point(x, y));
         add(sigma1Label);
+        
         
         // Center the first modulo addtion label in the x axis with the center 
         // of the 'd' working variable, which is inworkingVars[3] and 
@@ -421,6 +427,7 @@ public class CompressionCanvasView extends UserRequestView {
         wLabel.setLocation(x, y);
         add(wLabel);
         
+        
         // K input location
         x = modAdditions[2].getLocation().x;
         y = modAdditions[2].getLocation().y;
@@ -428,6 +435,14 @@ public class CompressionCanvasView extends UserRequestView {
         y -= VariableLabel.HALF_SIZE;
         kLabel.setLocation(x, y);
         add(kLabel);
+        
+         //Add counter label to the right of W location
+        
+        countX = modAdditions[2].getLocation().x + CounterLabel.SIZE * 3;
+        countY = inWorkingVars[7].getLocation().y - CounterLabel.HALF_SIZE ;
+        
+        counter.setLocation(countX, countY);
+        add(counter);
         
         // Third mod addition has Sigma1 inputs and centered on it
         x = sigma1Label.getLocation().x + BitOpLabel.HALF_SIZE - AddMod256Label.HALF_SIZE + 150;
@@ -460,14 +475,18 @@ public class CompressionCanvasView extends UserRequestView {
         temp2Label.setLocation(x, y);
         add(temp2Label);
         
+        
         // Add continueButton to the bottom right corner
         int buttonWidth = 100;
         int buttonHeight = 30;
         int margin = 10;
         x = getWidth() - buttonWidth - margin;
         y = getHeight() - buttonHeight - margin;
+        
         continueButton.setBounds(x, y, buttonWidth, buttonHeight);
         add(continueButton);
+        
+        
     }
     
     @Override

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/CounterLabel.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/CounterLabel.java
@@ -1,0 +1,69 @@
+/*
+ * SHATU: SHA-256 Tutor
+ * 
+ *  (C) Johanna & Richard Blumenthal, All rights reserved
+ * 
+ *  Unauthorized use, duplication or distribution without the authors'
+ *  permission is strictly prohibited.
+ * 
+ *  Unless required by applicable law or agreed to in writing, this
+ *  software is distributed on an "AS IS" basis without warranties
+ *  or conditions of any kind, either expressed or implied.
+ */
+package edu.regis.shatu.view;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+
+import javax.swing.BorderFactory;
+import javax.swing.JLabel;
+import javax.swing.SwingConstants;
+import javax.swing.border.Border;
+import javax.swing.border.CompoundBorder;
+import javax.swing.border.EmptyBorder;
+
+
+/**
+ *
+ * @author watkinskris
+ */
+public class CounterLabel extends JLabel{
+    /**
+     * The pixel width and height of this component.
+     */
+    public static final int SIZE = 100;
+    
+    public static final int HALF_SIZE = SIZE / 4;
+    
+        /**
+     * This empty border serves as an inset so the text doesn't touch the edges.
+     */
+    private static final Border EMPTY_BORDER = new EmptyBorder(5, 10, 5, 10);
+
+    /**
+     * A simple black line surrounds this label when not highlighted.
+     */
+    private static final Border NORMAL_BORDER
+            = new CompoundBorder(BorderFactory.createLineBorder(Color.BLUE), EMPTY_BORDER);
+    
+    /**
+     * The background of this label is pinkish when not highlighted.
+     */
+    private static final Color NORMAL_BACKGROUND = new Color(230,230,250);
+    
+    public CounterLabel(String text) {
+        super(text, SwingConstants.CENTER);
+        
+
+        Dimension d = new Dimension(SIZE, HALF_SIZE); // Determined empirically
+
+        setOpaque(true);
+        setBackground(NORMAL_BACKGROUND);
+        setBorder(NORMAL_BORDER);
+        setMinimumSize(d);
+        setSize(d);
+
+    }
+}


### PR DESCRIPTION
Counter label was added to show the round that is
currently being completed during the 64
Compression rounds of the SHA256 hash to better
enable the visualization and understanding of
the calculations in each round.  Does not actually 
work but is a place holder until CompressionRoundStep 
Model is complete