### PR TITLE
SHAT-237 Refactor, Tutor, Views (See Comments)

### DIFF
--- a/ShaTuApp/src/main/java/edu/regis/shatu/svc/ShaTuTutor.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/svc/ShaTuTutor.java
@@ -41,6 +41,7 @@ import edu.regis.shatu.model.aol.NewExampleRequest;
 import edu.regis.shatu.model.aol.PendingStep;
 import edu.regis.shatu.model.aol.PendingTask;
 import edu.regis.shatu.model.aol.ProblemType;
+import edu.regis.shatu.model.aol.StepSubType;
 import edu.regis.shatu.model.aol.StudentModel;
 import edu.regis.shatu.objectives.AddBits;
 import edu.regis.shatu.objectives.AddMsgLen;
@@ -460,26 +461,10 @@ public class ShaTuTutor implements TutorSvc {
         switch (step.getSubType()) {
             case INFO_MESSAGE:
                 return completeInfoMsgStep(completion);
-            case ENCODE_BINARY: // TO_DO: Really the same
-            case ENCODE_HEX:
-            case ENCODE_ASCII:
-            case ADD_ONE_BIT:
-            case PAD_ZEROS:
-            case ADD_MSG_LENGTH:
-            case PREPARE_SCHEDULE:
-            case INITIALIZE_VARS:
-            case COMPRESS_ROUND:
-            case ROTATE_BITS:
-            case SHIFT_BITS:
-            case XOR_BITS:
-            case ADD_BITS:
-            case MAJORITY_FUNCTION:
-            case CHOICE_FUNCTION:
-            case SHA_ZERO:
-                return currObjective.hint(completion);
 
             default:
-                return createError("Unknown step completion: " + step.getSubType(), null);
+                currObjective = getCurrentObjectiveByProbelmType(convertStepToProblemType(step.getSubType()));
+                return currObjective.hint(completion);
         }
     }
 
@@ -493,31 +478,14 @@ public class ShaTuTutor implements TutorSvc {
         StepCompletion completion = gson.fromJson(jsonObj, StepCompletion.class);
 
         Step step = completion.getStep();
-
+ 
         switch (step.getSubType()) {
             case INFO_MESSAGE:
-                return completeInfoMsgStep(completion);
-
-            case ENCODE_BINARY: // TO_DO: Really the same
-            case ENCODE_HEX:
-            case ENCODE_ASCII:
-            case ADD_ONE_BIT:
-            case PAD_ZEROS:
-            case ADD_MSG_LENGTH:
-            case PREPARE_SCHEDULE:
-            case INITIALIZE_VARS:
-            case COMPRESS_ROUND:
-            case ROTATE_BITS:
-            case SHIFT_BITS:
-            case XOR_BITS:
-            case ADD_BITS:
-            case MAJORITY_FUNCTION:
-            case CHOICE_FUNCTION:
-            case SHA_ZERO:
-                return currObjective.completeStep(completion);
+                return completeInfoMsgStep(completion); 
 
             default:
-                return createError("Unknown step completion: " + step.getSubType(), null);
+                currObjective = getCurrentObjectiveByProbelmType(convertStepToProblemType(step.getSubType()));
+                return currObjective.completeStep(completion);
         }
     }
 
@@ -538,29 +506,100 @@ public class ShaTuTutor implements TutorSvc {
      * @return TutorReply
      */
     public TutorReply newExample(String json) {
-        // gson = new GsonBuilder().setPrettyPrinting().create();
+        System.out.println("nexExample()");
 
         NewExampleRequest request = gson.fromJson(json, NewExampleRequest.class);
-
-        switch (request.getExampleType()) {
-            case ADD_ONE_BIT:
-            case PAD_ZEROS:
-            case ADD_MSG_LENGTH:
+        
+        currObjective = getCurrentObjectiveByProbelmType(request.getExampleType());
+ 
+        return currObjective.example(session, request.getData());
+    }
+    
+    /**
+     * 
+     * ToDO: Can ProblemType and StepSubType be combined?
+     * 
+     * @param problemType
+     * @return 
+     */
+    private Objective getCurrentObjectiveByProbelmType(ProblemType problemType) {
+        switch (problemType) {
             case PREPARE_SCHEDULE:
-            case INITIALIZE_VARS:
+                return new PrepareSchedule(student);
             case COMPRESS_ROUND:
-            case ROTATE_BITS:
+                return new CompressRound(student);
             case SHIFT_BITS:
+                return new ShiftBits(student);
             case XOR_BITS:
+                return  new XorBits(student);
             case ADD_BITS:
+                return new AddBits(student);
             case MAJORITY_FUNCTION:
+                return new MajorityFunction(student);
+            case ADD_ONE_BIT:
+                return new AddOne(student);
+            case PAD_ZEROS:
+                return new PadZeros(student);
+            case ROTATE_BITS:
+                return new RotateBits(student);
+            case INITIALIZE_VARS:
+                return new InitVars(student);
             case CHOICE_FUNCTION:
-            case SHA_ZERO:
+                return new ChoiceFunction(student);
+            case ADD_MSG_LENGTH:
+                return new AddMsgLen(student);
             case ASCII_ENCODE:
-                return currObjective.example(session, request.getData());
-
+                return new EncodeAscii(student);
             default:
-                return createError("Unknown new example request: " + request.getExampleType(), null);
+                System.out.println("ShaUnknown new example request: " + problemType);
+                return null;
+        }
+    }
+    
+    /**
+     * KLUDGE
+     * ToDO: Can ProblemType and StepSubType be combined?
+     * 
+     * @param stepType
+     * @return 
+     */
+    private ProblemType convertStepToProblemType(StepSubType stepType) {
+        switch (stepType) {
+            case ENCODE_BINARY: 
+            case ENCODE_HEX:
+            case ENCODE_ASCII:
+                return ProblemType.ASCII_ENCODE;
+            case ADD_ONE_BIT:
+                return ProblemType.ADD_ONE_BIT;
+            case PAD_ZEROS:
+                return ProblemType.PAD_ZEROS;
+            case ADD_MSG_LENGTH:
+                return ProblemType.ADD_MSG_LENGTH;
+            case PREPARE_SCHEDULE:
+                return ProblemType.PREPARE_SCHEDULE;
+            case INITIALIZE_VARS:
+                return ProblemType.INITIALIZE_VARS;
+            case COMPRESS_ROUND:
+                return ProblemType.COMPRESS_ROUND;
+            case ROTATE_BITS:
+                return ProblemType.ROTATE_BITS;
+            case SHIFT_BITS:
+                return ProblemType.SHIFT_BITS;
+            case XOR_BITS:
+                return ProblemType.XOR_BITS;
+            case ADD_BITS:
+                return ProblemType.ADD_BITS;
+            case MAJORITY_FUNCTION:
+                return ProblemType.MAJORITY_FUNCTION;
+            case CHOICE_FUNCTION:
+                return ProblemType.CHOICE_FUNCTION;
+            case SHA_ZERO:
+                return ProblemType.SHA_ZERO;
+            //case SHA_ONE:
+            //    return ProblemType.SHA_ONE;
+            default:
+                System.out.println("Unknown step type in convert: " + stepType);
+                return null;
         }
     }
 

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/Add1View.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/Add1View.java
@@ -17,13 +17,8 @@
 package edu.regis.shatu.view;
 
 import java.awt.Dimension;
-import java.awt.FlowLayout;
 import java.awt.GridBagConstraints;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-
 import javax.swing.BoxLayout;
-import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
@@ -33,19 +28,12 @@ import javax.swing.JTextField;
 import javax.swing.JTextPane;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-
 import edu.regis.shatu.model.AddOneStep;
 import edu.regis.shatu.model.Step;
 import edu.regis.shatu.model.StepCompletion;
 import edu.regis.shatu.model.aol.NewExampleRequest;
 import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.aol.StepSubType;
-import edu.regis.shatu.view.act.HintAction;
-import edu.regis.shatu.view.act.NewExampleAction;
-import edu.regis.shatu.view.act.StepCompletionAction;
 
 /**
  * A view that requests the student to add a single '1' bit to the byte prompt.
@@ -60,8 +48,6 @@ public class Add1View extends UserRequestView {
     private JTextField messageLengthField;
     private JTextArea responseTextArea;
     private JTextArea feedbackArea;
-    private JButton checkButton, nextButton, hintButton;
-    private boolean checkHintEnabled = false;
     private JTable asciiTable;
     private JScrollPane responseScrollPane, asciiTableScrollPane, feedbackScrollPane;
     private String question;
@@ -137,6 +123,10 @@ public class Add1View extends UserRequestView {
         addc(feedbackScrollPane, 0, 5, 1, 1,
                 1.0, 1.0, GridBagConstraints.CENTER,
                 GridBagConstraints.BOTH, 5, 5, 5, 5);
+        
+        addc(buttonPanel, 0, 6, 1, 1, 0.0, 0.0,
+                GridBagConstraints.CENTER, GridBagConstraints.NONE,
+                5, 5, 5, 5);
     }
 
     /**
@@ -364,14 +354,9 @@ public class Add1View extends UserRequestView {
      */
     @Override
     protected void updatePracticeView() {
-
-        hintButton = view.getHintButton();
-        checkButton = view.getCheckButton();
-        nextButton = view.getNewExampleButton();
-
         // If check and hint buttons are disabled, reset listenerers and apply those used by this view
         if (!checkHintEnabled) {
-            view.resetButtonListeners(); // Clear any listeners applied from other views
+            resetButtonListeners(); // Clear any listeners applied from other views
         }
 
         /*
@@ -382,8 +367,6 @@ public class Add1View extends UserRequestView {
         StepSubType type = StepSubType.ADD_ONE_BIT;
 
         System.out.println("Add One Bit update display called"); // Error checking
-
-        Gson gson = new GsonBuilder().setPrettyPrinting().create(); // May not be needed here.
 
         Step step = model.currentTask().getCurrentStep().getStep(); // Will be the last subtype a example was created for or empty
 

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/AddTwoBitView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/AddTwoBitView.java
@@ -18,29 +18,21 @@ package edu.regis.shatu.view;
 
 import java.awt.GridBagConstraints;
 import java.awt.Insets;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.math.BigInteger;
-
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JTextField;
-
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-
 import edu.regis.shatu.model.Step;
 import edu.regis.shatu.model.StepCompletion;
 import edu.regis.shatu.model.aol.BitOpStep;
 import edu.regis.shatu.model.aol.NewExampleRequest;
 import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.aol.StepSubType;
-import edu.regis.shatu.view.act.HintAction;
-import edu.regis.shatu.view.act.NewExampleAction;
-import edu.regis.shatu.view.act.StepCompletionAction;
 
 /**
  * AddTwoBitView class represents a GUI view for adding two binary numbers
@@ -69,10 +61,6 @@ public class AddTwoBitView extends UserRequestView implements KeyListener {
     private JLabel stringLabel2;
     private JLabel stringLabel3;
     private JLabel stringLabel4; // Only for testing that view is communicating with server
-    private JButton checkButton; // Add the check button
-    private JButton hintButton;
-    private JButton nextButton;
-    private boolean checkHintEnabled = false;
 
     /**
      * Initializes the AddTwoBitView by creating and laying out its child
@@ -138,6 +126,10 @@ public class AddTwoBitView extends UserRequestView implements KeyListener {
                 5, 5, 5, 5);
 
         responseTextArea.setEnabled(false);  // Text area disabled at initialization 
+        
+        addc(buttonPanel, 0, 5, 1, 1, 0.0, 0.0,
+                GridBagConstraints.CENTER, GridBagConstraints.NONE,
+                5, 5, 5, 5);
 
     }
 
@@ -327,17 +319,12 @@ public class AddTwoBitView extends UserRequestView implements KeyListener {
      */
     @Override
     protected void updatePracticeView() {
-
-        hintButton = view.getHintButton();
-        checkButton = view.getCheckButton();
-        nextButton = view.getNewExampleButton();
-
         responseTextArea.setText("");
 
         // If check and hint buttons are disabled, reset listenerers and apply those
         // used by this view
         if (!checkHintEnabled) {
-            view.resetButtonListeners(); // Clear any listeners applied from other views
+            resetButtonListeners(); // Clear any listeners applied from other views
         }
 
         if (model != null) {
@@ -345,8 +332,6 @@ public class AddTwoBitView extends UserRequestView implements KeyListener {
             // Update the view's information from the model
             // Debugging dynamic updates to the model can be done here.
             System.out.println("AddTwoBitView");
-
-            Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
             Step step = model.currentTask().getCurrentStep().getStep();
 

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/ChoiceFunctionView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/ChoiceFunctionView.java
@@ -43,9 +43,6 @@ import edu.regis.shatu.model.StepCompletion;
 import edu.regis.shatu.model.aol.NewExampleRequest;
 import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.aol.StepSubType;
-import edu.regis.shatu.view.act.HintAction;
-import edu.regis.shatu.view.act.NewExampleAction;
-import edu.regis.shatu.view.act.StepCompletionAction;
 
 /**
  * ChoiceFunctionView class represents a GUI view for a choice function Ch(x, y,
@@ -64,8 +61,7 @@ public class ChoiceFunctionView extends UserRequestView implements KeyListener {
     private GPanel truthTablePanel, questionPanel, descriptionPanel, qrPanel;
     private JPanel radioButtonPanel;
     private JTable chTruthTable;
-    private JButton checkButton, newExButton, hintButton, truthTableToggleButton;
-    private boolean checkHintEnabled = false;
+    private JButton truthTableToggleButton;
     private ButtonGroup problemSizeGroup;
     private JRadioButton fourRadioButton, eightRadioButton, sixteenRadioButton,
             thirtytwoRadioButton;
@@ -151,6 +147,10 @@ public class ChoiceFunctionView extends UserRequestView implements KeyListener {
 
         addc(qrPanel, 0, 2, 3, 1, 1.0, 1.0,
                 GridBagConstraints.NORTHWEST, GridBagConstraints.NONE,
+                5, 5, 5, 5);
+        
+        addc(buttonPanel, 0, 3, 1, 1, 0.0, 0.0,
+                GridBagConstraints.CENTER, GridBagConstraints.NONE,
                 5, 5, 5, 5);
     }
 
@@ -540,13 +540,13 @@ public class ChoiceFunctionView extends UserRequestView implements KeyListener {
     @Override
     protected void updatePracticeView() {
 
-        hintButton = view.getHintButton();
-        checkButton = view.getCheckButton();
-        newExButton = view.getNewExampleButton();
+       // hintButton = view.getHintButton();
+       // checkButton = view.getCheckButton();
+       // newExButton = view.getNewExampleButton();
 
         // If check and hint buttons are disabled, reset listenerers and apply those used by this view
         if (!checkHintEnabled) {
-            view.resetButtonListeners(); // Clear any listeners applied from other views
+           resetButtonListeners(); // Clear any listeners applied from other views
         }
 
         System.out.println("Choice function update view called."); // Error checking

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
@@ -27,8 +27,6 @@ import edu.regis.shatu.model.Step;
 import edu.regis.shatu.model.StepCompletion;
 import edu.regis.shatu.model.aol.NewExampleRequest;
 import edu.regis.shatu.model.aol.ProblemType;
-import edu.regis.shatu.view.act.NewExampleAction;
-import edu.regis.shatu.view.act.StepCompletionAction;
 import edu.regis.shatu.svc.SHA_256;
 import java.nio.charset.Charset;
 import javax.swing.JOptionPane;
@@ -646,10 +644,10 @@ public class CompressionCanvasView extends UserRequestView implements ActionList
      */
     @Override
     protected void updatePracticeView() {
-        view.resetButtonListeners(); // Clear any listeners applied from other views
-        view.getCheckButton().setEnabled(false);
-        view.getHintButton().setEnabled(false);
-        view.getNewExampleButton().setEnabled(false);
+        resetButtonListeners(); // Clear any listeners applied from other views
+        checkButton.setEnabled(false);
+        hintButton.setEnabled(false);
+        newExampleButton.setEnabled(false);
     }
 
     /**
@@ -693,8 +691,5 @@ public class CompressionCanvasView extends UserRequestView implements ActionList
         
         return step;
     }
-    
-    
-
 }
 

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/EncodeView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/EncodeView.java
@@ -15,10 +15,6 @@ package edu.regis.shatu.view;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.GridBagConstraints;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-
-import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
@@ -28,19 +24,12 @@ import javax.swing.JTextField;
 import javax.swing.JTextPane;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-
 import edu.regis.shatu.model.EncodeAsciiStep;
 import edu.regis.shatu.model.Step;
 import edu.regis.shatu.model.StepCompletion;
 import edu.regis.shatu.model.aol.NewExampleRequest;
 import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.aol.StepSubType;
-import edu.regis.shatu.view.act.HintAction;
-import edu.regis.shatu.view.act.NewExampleAction;
-import edu.regis.shatu.view.act.StepCompletionAction;
 
 /**
  * A view that requests the student to add a single '1' bit to the byte prompt.
@@ -55,8 +44,6 @@ public class EncodeView extends UserRequestView {
     private JTextField messageLengthField, setQuestionField;
     private JTextArea responseTextArea;
     private JTextArea feedbackArea;
-    private JButton checkButton, nextButton, hintButton;
-    private boolean checkHintEnabled = false;
     private JTable asciiTable;
     private JScrollPane responseScrollPane, asciiTableScrollPane, feedbackScrollPane;
     private String question;
@@ -67,7 +54,6 @@ public class EncodeView extends UserRequestView {
      * components.
      */
     public EncodeView() {
-
         initializeComponents();
         initializeLayout();
     }
@@ -113,6 +99,10 @@ public class EncodeView extends UserRequestView {
         addc(feedbackScrollPane, 0, 5, 1, 1,
                 1.0, 1.0, GridBagConstraints.CENTER,
                 GridBagConstraints.BOTH, 5, 5, 5, 5);
+        
+        addc(buttonPanel, 0, 6, 1, 1, 0.0, 0.0,
+                GridBagConstraints.CENTER, GridBagConstraints.NONE,
+                5, 5, 5, 5);
     }
 
     /**
@@ -344,8 +334,6 @@ public class EncodeView extends UserRequestView {
             StepSubType type = StepSubType.ENCODE_ASCII;
 
             System.out.println("Encode ASCII update display called"); // Error checking
-
-            Gson gson = new GsonBuilder().setPrettyPrinting().create(); // May not be needed here.
 
             Step step = model.currentTask().getCurrentStep().getStep(); // Will be the last subtype a example was
             // created for or empty

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/ExclusiveOrView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/ExclusiveOrView.java
@@ -19,7 +19,6 @@ import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.GridBagConstraints;
-import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
@@ -45,9 +44,6 @@ import edu.regis.shatu.model.aol.BitOpStep;
 import edu.regis.shatu.model.aol.NewExampleRequest;
 import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.aol.StepSubType;
-import edu.regis.shatu.view.act.HintAction;
-import edu.regis.shatu.view.act.NewExampleAction;
-import edu.regis.shatu.view.act.StepCompletionAction;
 
 /**
  * ExclusiveOrView class represents a GUI view for performing Exclusive OR (XOR)
@@ -66,8 +62,6 @@ public class ExclusiveOrView extends UserRequestView implements KeyListener {
     private JScrollPane feedbackPane, responsePane;
     private GPanel questionPanel, descriptionPanel, qrPanel;
     private JPanel  radioButtonPanel;
-    private JButton checkButton, hintButton, newExampleButton;
-    private boolean checkHintEnabled = false;
     private ButtonGroup problemSizeGroup;
     private JRadioButton fourRadioButton, eightRadioButton, sixteenRadioButton,
             thirtytwoRadioButton;
@@ -112,6 +106,10 @@ public class ExclusiveOrView extends UserRequestView implements KeyListener {
 
         addc(qrPanel, 0, 2, 3, 1, 1.0, 1.0,
                 GridBagConstraints.NORTHWEST, GridBagConstraints.NONE,
+                5, 5, 5, 5);
+                
+        addc(buttonPanel, 0, 3, 1, 1, 0.0, 0.0,
+                GridBagConstraints.CENTER, GridBagConstraints.NONE,
                 5, 5, 5, 5);
     }
 
@@ -521,21 +519,15 @@ public class ExclusiveOrView extends UserRequestView implements KeyListener {
      */
     @Override
     protected void updatePracticeView() {
-
-        hintButton = view.getHintButton();
-        checkButton = view.getCheckButton();
-        newExampleButton = view.getNewExampleButton();
-
         responseTextArea.setText("");
         feedbackTextArea.setText("");
 
         // If check and hint buttons are disabled, reset listenerers and apply those used by this view
         if (!checkHintEnabled) {
-            view.resetButtonListeners(); // Clear any listeners applied from other views
+            resetButtonListeners(); // Clear any listeners applied from other views
         }
 
         if (model != null) {
-            Gson gson = new GsonBuilder().setPrettyPrinting().create();
             Step step = model.currentTask().getCurrentStep().getStep();
 
             if (step.getSubType() == StepSubType.XOR_BITS) {

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/InitVarView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/InitVarView.java
@@ -13,225 +13,143 @@
 package edu.regis.shatu.view;
 
 import java.awt.Color;
-import java.awt.FlowLayout;
-import java.awt.GridBagConstraints;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-
-import javax.swing.JButton;
 import javax.swing.JLabel;
-import javax.swing.JPanel;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
-import java.awt.GridBagLayout;
 import java.awt.GridBagConstraints;
-import java.awt.Insets;
-import java.awt.Dimension;
 import java.awt.Font;
-
-
 import edu.regis.shatu.model.InitVarStep;
 import edu.regis.shatu.model.Step;
 import edu.regis.shatu.model.StepCompletion;
 import edu.regis.shatu.model.aol.NewExampleRequest;
 import edu.regis.shatu.model.aol.ProblemType;
-import edu.regis.shatu.view.act.NewExampleAction;
-import edu.regis.shatu.view.act.StepCompletionAction;
 
 /**
  *
  * @author rickb, Ryley MacLagan
  */
-public class InitVarView extends UserRequestView implements ActionListener {
-    
+public class InitVarView extends UserRequestView { // implements ActionListener
+
+    /**
+     * SHA256 has eight initial H variables H0 ... H7.
+     */
+    private static final int NUM_VARS = 8;
+
     private TutoringSessionView view;
     private InitVarStep initVarStep;
-    private JButton showButton, hintButton, checkButton;
-    private JTextField h0, h1, h2, h3, h4, h5, h6, h7;
+
+    private JTextField[] hVars;
     private JTextArea feedbackTextArea;
     private short hintCount;
     private boolean answersVisible, hintsVisible;
     private JLabel[] answerLabels = new JLabel[8];  // Holds correct answer labels
 
-    public InitVarView() { 
+    public InitVarView() {
         initializeComponents();
         initializeLayout();
         attachDocumentListeners();
     }
-    
+
+    /*
     @Override
     public void actionPerformed(ActionEvent event) {
         if (event.getSource() == checkButton) {
             NewExampleAction.instance().actionPerformed(null);
             boolean allCorrect = initVarStep.allAnswersCorrect();
-            
-            if(allCorrect){
+
+            if (allCorrect) {
                 showAnswer();
                 feedbackTextArea.setText("Correct!");
-            }
-            else{
+            } else {
                 feedbackTextArea.setText("Incorrect. Please try again or use a hint.");
             }
         } else if (event.getSource() == hintButton) {
             showHint();
         }
     }
-
+     */
     private void initializeComponents() {
-    initVarStep = new InitVarStep();
-    hintCount = 1;
-    answersVisible = false;
-    hintsVisible = false;
+        hVars = new JTextField[NUM_VARS];
 
-    Dimension textFieldSize = new Dimension(200, 30); // Adjust width and height
+        for (int i = 0; i < NUM_VARS; i++) {
+            hVars[i] = new JTextField(20);
+            hVars[i].setName("H" + i);
+        }
 
-    h0 = new JTextField(20); h0.setName("@H0"); h0.setPreferredSize(textFieldSize);
-    h1 = new JTextField(20); h1.setName("@H1"); h1.setPreferredSize(textFieldSize);
-    h2 = new JTextField(20); h2.setName("@H2"); h2.setPreferredSize(textFieldSize);
-    h3 = new JTextField(20); h3.setName("@H3"); h3.setPreferredSize(textFieldSize);
-    h4 = new JTextField(20); h4.setName("@H4"); h4.setPreferredSize(textFieldSize);
-    h5 = new JTextField(20); h5.setName("@H5"); h5.setPreferredSize(textFieldSize);
-    h6 = new JTextField(20); h6.setName("@H6"); h6.setPreferredSize(textFieldSize);
-    h7 = new JTextField(20); h7.setName("@H7"); h7.setPreferredSize(textFieldSize);
+        // Initialize answer labels
+        for (int i = 0; i < 8; i++) {
+            answerLabels[i] = new JLabel(""); // Empty initially
+            answerLabels[i].setFont(new Font("SansSerif", Font.BOLD, 12));
+            answerLabels[i].setForeground(Color.BLUE);
+        }
 
-    // Initialize answer labels
-    for (int i = 0; i < 8; i++) {
-        answerLabels[i] = new JLabel(""); // Empty initially
-        answerLabels[i].setFont(new Font("SansSerif", Font.BOLD, 12));
-        answerLabels[i].setForeground(Color.BLUE);
-    }
-
-    feedbackTextArea = new JTextArea(3, 20);
-    feedbackTextArea.setEditable(false);
-    feedbackTextArea.setLineWrap(true);
-    feedbackTextArea.setWrapStyleWord(true);
-    feedbackTextArea.setBackground(null);
-
-    showButton = new JButton("Show Answer");
-    showButton.addActionListener(e -> showAnswer());
-    hintButton = new JButton("Hint");
-    checkButton = new JButton(StepCompletionAction.instance());
-    checkButton.setText("Check");
+        feedbackTextArea = new JTextArea(3, 20);
+        feedbackTextArea.setEditable(false);
+        feedbackTextArea.setLineWrap(true);
+        feedbackTextArea.setWrapStyleWord(true);
+        feedbackTextArea.setBackground(null);
     }
 
     private void initializeLayout() {
-    setLayout(new GridBagLayout());
-    GridBagConstraints gbc = new GridBagConstraints();
+        // Use JLabel with HTML to ensure proper paragraph formatting
+        JLabel infoLabel = new JLabel("<html><div style='width: 500px;'>"
+                + "<p>In SHA-256, the algorithm begins with a set of initial hash values, "
+                + "which are specifically chosen constants. These constants are derived from the "
+                + "first 32 bits of the fractional parts of the square roots of the first 8 prime numbers. "
+                + "They serve as the starting points for the hash computation and ensure that the "
+                + "algorithm starts from a random-like state.</p><p>"
+                + "Please enter the initial hash values in hexadecimal for H0 to H7 below:<br>"
+                + "(Incorrect answers are in red, and turn green when correct.)</p></div></html>");
 
-    // Use JLabel with HTML to ensure proper paragraph formatting
-    JLabel infoLabel = new JLabel("<html><div style='width: 500px;'>"
-            + "<p>In SHA-256, the algorithm begins with a set of initial hash values, "
-            + "which are specifically chosen constants. These constants are derived from the "
-            + "first 32 bits of the fractional parts of the square roots of the first 8 prime numbers. "
-            + "They serve as the starting points for the hash computation and ensure that the "
-            + "algorithm starts from a random-like state.</p><p>"
-            + "Please enter the initial hash values in hexadecimal for H0 to H7 below:<br>"
-            + "(Incorrect answers are in red, and turn green when correct.)</p></div></html>");
+        infoLabel.setFont(new Font("SansSerif", Font.PLAIN, 14));
 
-    infoLabel.setFont(new Font("SansSerif", Font.PLAIN, 14));
+        addc(infoLabel, 0, 0, 2, 1, 1.0, 0.0,
+                GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL,
+                5, 5, 5, 5);
 
-    gbc.gridx = 0;
-    gbc.gridy = 0;
-    gbc.gridwidth = 3; // Make it span multiple columns for better readability
-    gbc.fill = GridBagConstraints.HORIZONTAL;
-    gbc.insets = new Insets(10, 10, 10, 10);
-    add(infoLabel, gbc);
+        int gridX = 1;
+        for (int i = 0; i < NUM_VARS; i++, gridX++) {
+            JLabel label = new JLabel(hVars[i].getName());
+            label.setLabelFor(hVars[i]);
+            addc(label, 0, gridX, 1, 1, 0.0, 0.0,
+                    GridBagConstraints.CENTER, GridBagConstraints.NONE,
+                    5, 5, 5, 5);
 
-    // Labels, input fields, and answer labels
-    gbc.gridwidth = 1;
-    gbc.anchor = GridBagConstraints.WEST;
-
-    JTextField[] inputFields = {h0, h1, h2, h3, h4, h5, h6, h7};
-    String[] labels = {"H0:", "H1:", "H2:", "H3:", "H4:", "H5:", "H6:", "H7:"};
-
-    for (int i = 0; i < 8; i++) {
-        gbc.gridy = i + 1;
-
-        // Column 1: Label (e.g., "H0:")
-        gbc.gridx = 0;
-        JLabel label = new JLabel(labels[i]);
-        label.setFont(new Font("SansSerif", Font.BOLD, 14));
-        add(label, gbc);
-
-        // Column 2: Input Field
-        gbc.gridx = 1;
-        inputFields[i].setPreferredSize(new Dimension(150, 25));
-        add(inputFields[i], gbc);
-
-        // Column 3: Answer Label (Initially Hidden)
-        gbc.gridx = 2;
-        answerLabels[i] = new JLabel(""); // Empty initially
-        answerLabels[i].setFont(new Font("SansSerif", Font.BOLD, 12));
-        answerLabels[i].setForeground(Color.BLUE);
-        add(answerLabels[i], gbc);
-    }
-
-    // Show Answer Button
-    gbc.gridx = 0;
-    gbc.gridy = 10;
-    gbc.gridwidth = 3;
-    gbc.anchor = GridBagConstraints.CENTER;
-    JButton showButton = new JButton("Show Answer");
-    showButton.addActionListener(e -> showAnswer());
-    add(showButton, gbc);
+            addc(hVars[i], 1, gridX, 1, 1, 1.0, 0.0,
+                    GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL,
+                    5, 5, 5, 5);
+        }
+        
+        addc(buttonPanel, 0, gridX, 2, 1, 0.0, 0.0,
+                GridBagConstraints.CENTER, GridBagConstraints.NONE,
+                5, 5, 5, 5);
     }
 
     /**
-     * Creates and adds a label for a text field to the GUI.
-     * @param labelText references an initial variable.
-     * @param textField holds the user's answer.
-     * @param gridY The position on the y-axis to place the label and text field.
-     */
-    private void createLabelForField(String labelText, JTextField textField, int gridY) {
-    JLabel label = new JLabel(labelText);  // Ensure label is separate from the text field
-    label.setFont(new Font("SansSerif", Font.BOLD, 12));  // Make it bold for visibility
-
-    textField.setPreferredSize(new Dimension(250, 30));  // Set proper size
-    textField.setFont(new Font("SansSerif", Font.PLAIN, 14)); // Ensure the font is readable
-    textField.setHorizontalAlignment(JTextField.LEFT); // Align text to the left
-
-    GridBagConstraints gbc = new GridBagConstraints();
-    
-    // Label on the left
-    gbc.gridx = 0;
-    gbc.gridy = gridY;
-    gbc.anchor = GridBagConstraints.WEST; // Align left
-    gbc.insets = new Insets(5, 5, 5, 10); // Add spacing
-    add(label, gbc);
-
-    // Text field on the right
-    gbc.gridx = 1;
-    gbc.fill = GridBagConstraints.HORIZONTAL;
-    add(textField, gbc);
-    }
-
-    /**
-     * Monitors all text fields for initial variable labels.
-     * Sets text color to red until correct.
-     * Correct answers are set to a dark green.
+     * Monitors all text fields for initial variable labels. Sets text color to
+     * red until correct. Correct answers are set to a dark green.
      */
     private void attachDocumentListeners() {
         DocumentListener docListener = new DocumentListener() {
             @Override
             public void insertUpdate(DocumentEvent e) {
                 checkInput(e);
-                if (!checkButton.isEnabled() && !hintButton.isEnabled()){
-                    view.toggleButton(checkButton);
-                    view.toggleButton(hintButton);
-                }
-                else if (!checkButton.isEnabled()) {
-                    view.toggleButton(checkButton);
-                }
+                // if (!checkButton.isEnabled() && !hintButton.isEnabled()) {
+                //     view.toggleButton(checkButton);
+                //    view.toggleButton(hintButton);
+                // } else if (!checkButton.isEnabled()) {
+                //     view.toggleButton(checkButton);
+                // }
             }
 
             @Override
             public void removeUpdate(DocumentEvent e) {
                 checkInput(e);
-                if(allFieldsEmpty()){
-                    checkButton.setEnabled(false);
-                }
+                //  if (allFieldsEmpty()) {
+                //      checkButton.setEnabled(false);
+                // }
             }
 
             @Override
@@ -243,9 +161,9 @@ public class InitVarView extends UserRequestView implements ActionListener {
                 JTextField sourceField = (JTextField) e.getDocument().getProperty("field");
                 String variableName = sourceField.getName();  // Use a unique name or identifier for each JTextField
                 String userAnswer = sourceField.getText();
-                
+
                 initVarStep.setUserAnswer(variableName, userAnswer);
-                
+
                 if (initVarStep.isUserCorrect(variableName)) {
                     sourceField.setForeground(Color.GREEN.darker().darker());
                 } else {
@@ -254,208 +172,32 @@ public class InitVarView extends UserRequestView implements ActionListener {
             }
         };
 
-        h0.getDocument().putProperty("field", h0);
-        h1.getDocument().putProperty("field", h1);
-        h2.getDocument().putProperty("field", h2);
-        h3.getDocument().putProperty("field", h3);
-        h4.getDocument().putProperty("field", h4);
-        h5.getDocument().putProperty("field", h5);
-        h6.getDocument().putProperty("field", h6);
-        h7.getDocument().putProperty("field", h7);
-
-        h0.getDocument().addDocumentListener(docListener);
-        h1.getDocument().addDocumentListener(docListener);
-        h2.getDocument().addDocumentListener(docListener);
-        h3.getDocument().addDocumentListener(docListener);
-        h4.getDocument().addDocumentListener(docListener);
-        h5.getDocument().addDocumentListener(docListener);
-        h6.getDocument().addDocumentListener(docListener);
-        h7.getDocument().addDocumentListener(docListener);
-    }
-    
-    /**
-     * Adds a new row at the specified x and y values.
-     * @param labelText first field in each row, the label for the text field
-     * @param textField second field in each row, the text field accepting user input
-     * @param correctAnswer third field in each row, the correct answer for this row
-     * @param gridX the x coordinate for the row
-     * @param gridY the y coordinate for the row
-     */
-    private void addRowWithAnswer(String labelText, JTextField textField, String correctAnswer, int gridX, int gridY) {
-        JPanel rowPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 5, 0)); // 5px horizontal gap, no vertical gap
-        JLabel label = new JLabel(labelText);
-        JLabel answerLabel = new JLabel(correctAnswer);
-        answerLabel.setForeground(Color.BLUE); // Set color for differentiation
-
-        rowPanel.add(label);
-        rowPanel.add(textField);
-        rowPanel.add(answerLabel);
-
-        GridBagConstraints gbc = new GridBagConstraints();
-        gbc.gridx = gridX;
-        gbc.gridy = gridY;
-        gbc.gridwidth = 2;
-        gbc.anchor = GridBagConstraints.WEST;
-        add(rowPanel, gbc);
-    }
-    
-    /**
-     * Adds a label containing an answer for its associated variable and text field.
-     */
-    private void addAnswerLabels() {
-        addRowWithAnswer("H0: ", h0, "Correct: " + initVarStep.getAnswer("@H0"), 0, 1);
-        addRowWithAnswer("H1: ", h1, "Correct: " + initVarStep.getAnswer("@H1"), 0, 2);
-        addRowWithAnswer("H2: ", h2, "Correct: " + initVarStep.getAnswer("@H2"), 0, 3);
-        addRowWithAnswer("H3: ", h3, "Correct: " + initVarStep.getAnswer("@H3"), 0, 4);
-        addRowWithAnswer("H4: ", h4, "Correct: " + initVarStep.getAnswer("@H4"), 0, 5);
-        addRowWithAnswer("H5: ", h5, "Correct: " + initVarStep.getAnswer("@H5"), 0, 6);
-        addRowWithAnswer("H6: ", h6, "Correct: " + initVarStep.getAnswer("@H6"), 0, 7);
-        addRowWithAnswer("H7: ", h7, "Correct: " + initVarStep.getAnswer("@H7"), 0, 8);
-    }
-    
-    /**
-     * Displays answers next to their corresponding variable and text field.
-     */
-    private void showAnswer() {
-    removeHints(); // Ensure hints don't interfere
-
-    if (answersVisible) {
-        // Hide answers
-        for (int i = 0; i < 8; i++) {
-            answerLabels[i].setText(""); // Clear answer labels
-        }
-        answersVisible = false;
-    } else {
-        // Show correct answers next to input fields
-        for (int i = 0; i < 8; i++) {
-            answerLabels[i].setText("Correct: " + initVarStep.getAnswer("@H" + i));
-        }
-        answersVisible = true;
-    }
-
-    revalidate();
-    repaint();
-    }
-    
-    /**
-     * Displays hints to the GUI for their corresponding variable's row.
-     * @param initVar the targeted variable's text field
-     * @param variableName the targeted variable's label
-     * @param hintLevel the level of hint (1st, 2nd, or 3rd hint)
-     * @param hintY the position on the y-axis to place the hint
-     */
-    private void addHints(JTextField initVar, String variableName, int hintLevel, int hintY) {
-        // Retrieve the hint for the specific variable and level
-        String hint = initVarStep.getHint(variableName, hintLevel);
-
-        // Only add the hint if it’s not null or empty
-        if (hint != null && !hint.isEmpty()) {
-            addRowWithAnswer(variableName + ": ", initVar, "Hint: " + hint, 1, hintY);
+        for (int i = 0; i < NUM_VARS; i++) {
+            // hVars[i].getDocument().putProperty("field", hVars[i]); // property is itself?
+            hVars[i].getDocument().addDocumentListener(docListener);
         }
     }
-    
-    /**
-     * Called when hint button is pressed.
-     * Determines if hints should be displayed to the user.
-     */
-    private void showHint() {
-        if (hintsVisible) {
-            removeHints();
-            hintsVisible = false;
-        } else {
-            removeExistingAnswerLabels();
-            if (hintCount > 3) hintCount = 1;
 
-            // Pass specific variable names to addHints for each text field
-            addHints(h0, "H0", hintCount, 1);
-            addHints(h1, "H1", hintCount, 2);
-            addHints(h2, "H2", hintCount, 3);
-            addHints(h3, "H3", hintCount, 4);
-            addHints(h4, "H4", hintCount, 5);
-            addHints(h5, "H5", hintCount, 6);
-            addHints(h6, "H6", hintCount, 7);
-            addHints(h7, "H7", hintCount, 8);
-
-            hintCount++;
-            hintsVisible = true;
-        }
-        revalidate();
-        repaint();
-    }
-    
     /**
-     * Removes all generated answer labels from the GUI
+     * Checks if all text fields are empty.
+     *
+     * @return true if all fields are empty, false otherwise.
      */
-    private void removeExistingAnswerLabels() {
-        // Remove only labels that start with "Correct:" from each row JPanel
-        for (int i = 0; i < getComponentCount(); i++) {
-            if (getComponent(i) instanceof JPanel) {
-                JPanel rowPanel = (JPanel) getComponent(i);
-                for (int j = rowPanel.getComponentCount() - 1; j >= 0; j--) {
-                    if (rowPanel.getComponent(j) instanceof JLabel) {
-                        JLabel label = (JLabel) rowPanel.getComponent(j);
-                        if (label.getText().startsWith("Correct:")) {
-                            rowPanel.remove(label); // Remove only the correct answer label
-                        }
-                    }
-                }
-            }
-        }
-    }
-    
-    // Removes all generated hints from the GUI
-    private void removeHints() {
-        // Remove only labels that start with "Hint:" from each row JPanel
-        for (int i = 0; i < getComponentCount(); i++) {
-            if (getComponent(i) instanceof JPanel) {
-                JPanel rowPanel = (JPanel) getComponent(i);
-                for (int j = rowPanel.getComponentCount() - 1; j >= 0; j--) {
-                    if (rowPanel.getComponent(j) instanceof JLabel) {
-                        JLabel label = (JLabel) rowPanel.getComponent(j);
-                        if (label.getText().startsWith("Hint:")) {
-                            rowPanel.remove(label); // Remove only the correct hint label
-                        }
-                    }
-                }
-            }
-        }
-    }
-    
-    /**
-    * Checks if all text fields are empty.
-    * 
-    * @return true if all fields are empty, false otherwise.
-    */
     public boolean allFieldsEmpty() {
-        return h0.getText().trim().isEmpty() &&
-               h1.getText().trim().isEmpty() &&
-               h2.getText().trim().isEmpty() &&
-               h3.getText().trim().isEmpty() &&
-               h4.getText().trim().isEmpty() &&
-               h5.getText().trim().isEmpty() &&
-               h6.getText().trim().isEmpty() &&
-               h7.getText().trim().isEmpty();
+        for (int i = 0; i < NUM_VARS; i++) {
+            if (!hVars[i].getText().trim().isEmpty()) {
+                return false;
+            }
+        }
+
+        return true;
     }
-    
-    /**
-     * Initializes Buttons for this view
-     * Attaches all unique listeners for this view
-     */
-    private void setupButtons() {
-        // Initializes Buttons
-        showButton = view.initializeButton("Show Answer");
-        hintButton = view.getHintButton();
-        hintButton.addActionListener(this);
-        checkButton = view.getCheckButton();
-        checkButton.addActionListener(this);
-    }
-    
+
     @Override
     protected void updateView() {
         view = SplashFrame.instance().getTutoringSessionView(); // Accessing view to use universal buttons
 
-        switch(view.getCurrentViewType())
-        {
+        switch (view.getCurrentViewType()) {
             case DO_ONE:
                 updatePracticeView();
                 break;
@@ -475,35 +217,36 @@ public class InitVarView extends UserRequestView implements ActionListener {
     }
 
     /**
-     * Defines each view classes' standard method for updating in the Practice View
+     * Defines each view classes' standard method for updating in the Practice
+     * View
      */
     @Override
     protected void updatePracticeView() {
-        view.resetButtonListeners(); // Clear any listeners applied from other views
+        resetButtonListeners(); // Clear any listeners applied from other views
         feedbackTextArea.setText(""); // Resets text feedback area
-        setupButtons();
+        //setupButtons();
 
         // New example is uniquely hidden for this view, as
         // There are only 8 initial values,
         // all of which the user shall define.
-        view.getNewExampleButton().setEnabled(false);
+        newExampleButton.setEnabled(false);
 
         if (model == null) {
             System.out.println("Error: The model is null when switching to Initialize Variables...");
-        }
-        else {
+        } else {
             // TODO: Debug statements. Task is not being set properly.
             // The model's tasks list holds only the first task. It must be populated with each task.
             // This should originate from a lack of data within the database.
             // Populating it should aid in resolving this error.
             System.out.println("Initialize update view called.");
-            System.out.println("----Init Var Task Title-----"+model.currentTask().getTask().getTitle());
-            System.out.println("----Init Var Step Title-----"+model.currentTask().getCurrentStep().getStep().getTitle());
+            System.out.println("----Init Var Task Title-----" + model.currentTask().getTask().getTitle());
+            System.out.println("----Init Var Step Title-----" + model.currentTask().getCurrentStep().getStep().getTitle());
         }
     }
 
     /**
-     * Defines each view classes' standard method for updating in the Teach Me View
+     * Defines each view classes' standard method for updating in the Teach Me
+     * View
      */
     @Override
     protected void updateTeachView() {
@@ -511,7 +254,8 @@ public class InitVarView extends UserRequestView implements ActionListener {
     }
 
     /**
-     * Defines each view classes' standard method for updating in the Teach Me View
+     * Defines each view classes' standard method for updating in the Teach Me
+     * View
      */
     @Override
     protected void updateQuizView() {
@@ -521,10 +265,10 @@ public class InitVarView extends UserRequestView implements ActionListener {
     @Override
     public NewExampleRequest newRequest() {
         NewExampleRequest ex = new NewExampleRequest();
-        
+
         //Set example type to the problem associated with the current view
         ex.setExampleType(ProblemType.INITIALIZE_VARS);
-        
+
         return ex;
     }
 
@@ -534,14 +278,10 @@ public class InitVarView extends UserRequestView implements ActionListener {
 
         // Populate InitVarStep with user input
         InitVarStep completedInitVarStep = new InitVarStep();
-        completedInitVarStep.setUserAnswer("@H0", h0.getText().trim());
-        completedInitVarStep.setUserAnswer("@H1", h1.getText().trim());
-        completedInitVarStep.setUserAnswer("@H2", h2.getText().trim());
-        completedInitVarStep.setUserAnswer("@H3", h3.getText().trim());
-        completedInitVarStep.setUserAnswer("@H4", h4.getText().trim());
-        completedInitVarStep.setUserAnswer("@H5", h5.getText().trim());
-        completedInitVarStep.setUserAnswer("@H6", h6.getText().trim());
-        completedInitVarStep.setUserAnswer("@H7", h7.getText().trim());
+
+        for (int i = 0; i < NUM_VARS; i++) {
+            completedInitVarStep.setUserAnswer(hVars[i].getName(), hVars[i].getText().trim());
+        }
 
         // Create StepCompletion with serialized JSON of dataWrapper
         StepCompletion stepCompletion = new StepCompletion(currentStep, gson.toJson(completedInitVarStep));

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/MajFunctionView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/MajFunctionView.java
@@ -19,11 +19,9 @@ import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.GridBagConstraints;
-import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
-
 import javax.swing.ButtonGroup;
 import javax.swing.JButton;
 import javax.swing.JLabel;
@@ -34,20 +32,12 @@ import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JTextArea;
 import javax.swing.table.DefaultTableCellRenderer;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-
 import edu.regis.shatu.model.MajorityStep;
 import edu.regis.shatu.model.Step;
 import edu.regis.shatu.model.StepCompletion;
 import edu.regis.shatu.model.aol.NewExampleRequest;
 import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.aol.StepSubType;
-import edu.regis.shatu.model.aol.ViewType;
-import edu.regis.shatu.view.act.HintAction;
-import edu.regis.shatu.view.act.NewExampleAction;
-import edu.regis.shatu.view.act.StepCompletionAction;
 
 /**
  * This class represents the GUI for the Majority (Maj) function exercise. Given
@@ -77,8 +67,6 @@ public class MajFunctionView extends UserRequestView implements KeyListener {
     private GPanel truthTablePanel, questionPanel, descriptionPanel, qrPanel;
     private JPanel radioButtonPanel;
     private JTable majTruthTable;
-    private JButton checkButton, nextButton, hintButton;
-    private boolean checkHintEnabled = false;
     private ButtonGroup problemSizeGroup;
     private JRadioButton fourRadioButton, eightRadioButton, sixteenRadioButton,
             thirtytwoRadioButton;
@@ -164,6 +152,10 @@ public class MajFunctionView extends UserRequestView implements KeyListener {
 
         addc(qrPanel, 0, 2, 3, 1, 1.0, 1.0,
                 GridBagConstraints.NORTHWEST, GridBagConstraints.NONE,
+                5, 5, 5, 5);
+                
+        addc(buttonPanel, 0, 3, 1, 1, 0.0, 0.0,
+                GridBagConstraints.CENTER, GridBagConstraints.NONE,
                 5, 5, 5, 5);
     }
 
@@ -624,17 +616,10 @@ public class MajFunctionView extends UserRequestView implements KeyListener {
      */
     @Override
     protected void updatePracticeView() {
-
-        hintButton = view.getHintButton();
-        checkButton = view.getCheckButton();
-        nextButton = view.getNewExampleButton();
-
         // If check and hint buttons are disabled, reset listenerers and apply those used by this view
         if (!checkHintEnabled) {
-            view.resetButtonListeners(); // Clear any listeners applied from other views
+            resetButtonListeners(); // Clear any listeners applied from other views
         }
-
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
         Step step = model.currentTask().getCurrentStep().getStep();
 

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/MessageLenView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/MessageLenView.java
@@ -15,32 +15,20 @@
  */
 package edu.regis.shatu.view;
 
-import java.awt.FlowLayout;
 import java.awt.GridBagConstraints;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-
 import javax.swing.BoxLayout;
-import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.JTextPane;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-
 import edu.regis.shatu.model.MessageLenStep;
 import edu.regis.shatu.model.Step;
 import edu.regis.shatu.model.StepCompletion;
 import edu.regis.shatu.model.aol.NewExampleRequest;
 import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.aol.StepSubType;
-import edu.regis.shatu.view.act.HintAction;
-import edu.regis.shatu.view.act.NewExampleAction;
-import edu.regis.shatu.view.act.StepCompletionAction;
 
 /**
  * A view that requests the student to figure out the number of bits their
@@ -57,8 +45,6 @@ public class MessageLenView extends UserRequestView {
     private JTextField messageLengthField;
     private JTextArea responseTextArea;
     private JTextArea feedbackArea;
-    private JButton checkButton, nextButton, hintButton;
-    private boolean checkHintEnabled = false;
     private JScrollPane responseScrollPane, feedbackScrollPane;
     private String question;
 
@@ -113,6 +99,10 @@ public class MessageLenView extends UserRequestView {
         addc(feedbackScrollPane, 0, 5, 1, 1,
                 1.0, 1.0, GridBagConstraints.CENTER,
                 GridBagConstraints.BOTH, 5, 5, 5, 5);
+                
+        addc(buttonPanel, 0, 6, 1, 1, 0.0, 0.0,
+                GridBagConstraints.CENTER, GridBagConstraints.NONE,
+                5, 5, 5, 5);
     }
 
     /**
@@ -297,13 +287,9 @@ public class MessageLenView extends UserRequestView {
     @Override
     protected void updatePracticeView() {
 
-        hintButton = view.getHintButton();
-        checkButton = view.getCheckButton();
-        nextButton = view.getNewExampleButton();
-
         // If check and hint buttons are disabled, reset listenerers and apply those used by this view
         if (!checkHintEnabled) {
-            view.resetButtonListeners(); // Clear any listeners applied from other views
+            resetButtonListeners(); // Clear any listeners applied from other views
         }
 
         /*
@@ -314,8 +300,6 @@ public class MessageLenView extends UserRequestView {
         StepSubType type = StepSubType.ADD_MSG_LENGTH;
 
         System.out.println("Message Length update display called"); // Error checking
-
-        Gson gson = new GsonBuilder().setPrettyPrinting().create(); // May not be needed here.
 
         Step step = model.currentTask().getCurrentStep().getStep(); // will be the last step a example was created for.
 

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/Pad0View.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/Pad0View.java
@@ -16,11 +16,7 @@
 package edu.regis.shatu.view;
 
 import java.awt.Dimension;
-import java.awt.FlowLayout;
 import java.awt.GridBagConstraints;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JLabel;
@@ -32,19 +28,12 @@ import javax.swing.JTextField;
 import javax.swing.JTextPane;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-
 import edu.regis.shatu.model.Pad0Step;
 import edu.regis.shatu.model.Step;
 import edu.regis.shatu.model.StepCompletion;
 import edu.regis.shatu.model.aol.NewExampleRequest;
 import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.aol.StepSubType;
-import edu.regis.shatu.view.act.HintAction;
-import edu.regis.shatu.view.act.NewExampleAction;
-import edu.regis.shatu.view.act.StepCompletionAction;
 
 /**
  * A view that requests the student to figure out the number of zeros needed to 
@@ -60,8 +49,6 @@ public class Pad0View extends UserRequestView {
     private JTextField messageLengthField;
     private JTextArea responseTextArea;
     private JTextArea feedbackArea;
-    private JButton checkButton, nextButton, hintButton;
-    private boolean checkHintEnabled = false;
     private JTable asciiTable;
     private JScrollPane responseScrollPane, asciiTableScrollPane, feedbackScrollPane;
     private String question;
@@ -118,6 +105,10 @@ public class Pad0View extends UserRequestView {
         addc(feedbackScrollPane, 0, 5, 1, 1, 
                 1.0, 1.0, GridBagConstraints.CENTER, 
                 GridBagConstraints.BOTH, 5, 5, 5, 5);
+                
+        addc(buttonPanel, 0, 6, 1, 1, 0.0, 0.0,
+                GridBagConstraints.CENTER, GridBagConstraints.NONE,
+                5, 5, 5, 5);
     }  
     
     /**
@@ -347,13 +338,9 @@ public class Pad0View extends UserRequestView {
     @Override
     protected void updatePracticeView() {
 
-        hintButton = view.getHintButton();
-        checkButton = view.getCheckButton();
-        nextButton = view.getNewExampleButton();
-
         // If check and hint buttons are disabled, reset listenerers and apply those used by this view
         if(!checkHintEnabled) {
-            view.resetButtonListeners(); // Clear any listeners applied from other views
+            resetButtonListeners(); // Clear any listeners applied from other views
         }
         /*
         When switching between steps, the current step will be the previous enum
@@ -363,8 +350,6 @@ public class Pad0View extends UserRequestView {
         StepSubType type = StepSubType.PAD_ZEROS;
 
         System.out.println("Pad Zero update display called"); // Error checking
-
-        Gson gson = new GsonBuilder().setPrettyPrinting().create(); // May not be needed here.
 
         Step step = model.currentTask().getCurrentStep().getStep(); // will be the last step a example was created for.
 

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/PrepareScheduleView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/PrepareScheduleView.java
@@ -13,20 +13,15 @@
 package edu.regis.shatu.view;
 
 import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import javax.swing.*;
 import java.util.Collections;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Random;
-
 import edu.regis.shatu.model.Step;
 import edu.regis.shatu.model.StepCompletion;
 import edu.regis.shatu.model.aol.NewExampleRequest;
 import edu.regis.shatu.model.aol.ProblemType;
-import edu.regis.shatu.view.act.NewExampleAction;
-import edu.regis.shatu.view.act.StepCompletionAction;
 
 /**
  * This class represents the Prepare Schedule operation step in a multiple-choice format.
@@ -34,13 +29,12 @@ import edu.regis.shatu.view.act.StepCompletionAction;
  * 
  * @author rickb
  */
-public class PrepareScheduleView extends UserRequestView implements ActionListener {
-
+public class PrepareScheduleView extends UserRequestView { //implements ActionListener {
     private TutoringSessionView view;
     private JLabel titleLabel, stepLabel, feedbackLabel, previousStepsLabel;
     private JRadioButton[] answerOptions;
     private ButtonGroup answerGroup;
-    private JButton checkAnswerButton, hintButton, newExampleButton;
+
     private int currentStep = 1;
     private int correctAnswerIndex; // Stores the shuffled position of the correct answer
 
@@ -65,20 +59,6 @@ public class PrepareScheduleView extends UserRequestView implements ActionListen
     }
 
     /**
-     * Handles button actions for checking answers, hints, and new examples.
-     */
-    @Override
-    public void actionPerformed(ActionEvent event) {
-        if (event.getSource() == checkAnswerButton) {
-            checkAnswer();
-        } else if (event.getSource() == hintButton) {
-            showHint();
-        } else if (event.getSource() == newExampleButton) {
-            loadNewExample();
-        }
-    }
-
-    /**
      * Initializes UI components.
      */
     private void initializeComponents() {
@@ -99,15 +79,6 @@ public class PrepareScheduleView extends UserRequestView implements ActionListen
             answerGroup.add(answerOptions[i]);
         }
 
-        checkAnswerButton = new JButton("Check Answer");
-        checkAnswerButton.addActionListener(this);
-
-        hintButton = new JButton("Hint");
-        hintButton.addActionListener(this);
-
-        newExampleButton = new JButton("New Example");
-        newExampleButton.addActionListener(this);
-
         feedbackLabel = new JLabel(""); // To display hints and feedback
         feedbackLabel.setHorizontalAlignment(SwingConstants.CENTER);
         feedbackLabel.setForeground(Color.BLUE); // System messages in blue
@@ -117,6 +88,26 @@ public class PrepareScheduleView extends UserRequestView implements ActionListen
      * Sets up the layout for the view.
      */
     private void initializeLayout() {
+        addc(titleLabel, 0, 0, 1, 1, 0.0, 0.0,
+                GridBagConstraints.CENTER, GridBagConstraints.NONE,
+                5, 5, 5, 5);
+        
+        addc(stepLabel, 0, 1, 1, 1, 1.0, 0.0,
+                GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL,
+                5, 5, 5, 5);
+        
+        int gridX = 2;
+        for (JRadioButton option : answerOptions) {
+            addc(option, 0, gridX++, 1, 1, 1.0, 0.0,
+                GridBagConstraints.NORTHWEST, GridBagConstraints.HORIZONTAL,
+                5, 5, 5, 5);
+         }
+        
+        addc(buttonPanel, 0, ++gridX, 1, 1, 0.0, 0.0,
+                GridBagConstraints.CENTER, GridBagConstraints.NONE,
+                5, 5, 5, 5);
+        
+        /*
         setLayout(new GridBagLayout());
         GridBagConstraints gbc = new GridBagConstraints();
         gbc.insets = new Insets(10, 10, 10, 10);
@@ -157,6 +148,7 @@ public class PrepareScheduleView extends UserRequestView implements ActionListen
 
         gbc.gridy++;
         add(newExampleButton, gbc);
+        */
     }
 
 
@@ -219,12 +211,6 @@ public class PrepareScheduleView extends UserRequestView implements ActionListen
         revalidate();
         repaint();
     }
-
-
-
-
-
-
 
     /**
      * Checks if the selected answer is correct.
@@ -360,7 +346,7 @@ public class PrepareScheduleView extends UserRequestView implements ActionListen
     @Override
     protected void updatePracticeView() {
 
-        view.resetButtonListeners();
+        resetButtonListeners();
 
         // Only update label if the step is greater than 1 to prevent overriding first question
         if (currentStep > 1) {

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/RotateView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/RotateView.java
@@ -17,17 +17,11 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
-
 import javax.swing.ButtonGroup;
-import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JRadioButton;
 import javax.swing.JTextField;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-
 import edu.regis.shatu.model.Step;
 import edu.regis.shatu.model.StepCompletion;
 import edu.regis.shatu.model.aol.NewExampleRequest;
@@ -35,9 +29,6 @@ import edu.regis.shatu.model.aol.PendingTask;
 import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.aol.RotateStep;
 import edu.regis.shatu.model.aol.StepSubType;
-import edu.regis.shatu.view.act.HintAction;
-import edu.regis.shatu.view.act.NewExampleAction;
-import edu.regis.shatu.view.act.StepCompletionAction;
 
 /**
  * RotateView class represents the GUI view for rotating strings using ROTR
@@ -58,8 +49,7 @@ public class RotateView extends UserRequestView implements KeyListener {
     private JLabel prompt;
     private JLabel problem;
     private JTextField answerField;
-    private JButton checkButton, hintButton, nextButton;
-    private boolean checkHintEnabled = false;
+
     private JRadioButton shortProblem;
     private JRadioButton longProblem;
     private JRadioButton rightRotate;
@@ -232,6 +222,10 @@ public class RotateView extends UserRequestView implements KeyListener {
         addc(rotate16Bits, 3, 7, 1, 1, 0.0, 0.0,
                 GridBagConstraints.WEST, GridBagConstraints.NONE,
                 5, 5, 5, 5);
+                
+        addc(buttonPanel, 0, 8, 4, 1, 0.0, 0.0,
+                GridBagConstraints.CENTER, GridBagConstraints.NONE,
+                5, 5, 5, 5);
     }
 
     @Override
@@ -281,17 +275,11 @@ public class RotateView extends UserRequestView implements KeyListener {
      */
     @Override
     protected void updatePracticeView() {
-
-        hintButton = view.getHintButton();
-        checkButton = view.getCheckButton();
-        nextButton = view.getNewExampleButton();
-
         // If check and hint buttons are disabled, reset listenerers and apply those used by this view
         if (!checkHintEnabled) {
-            view.resetButtonListeners(); // Clear any listeners applied from other views
+            resetButtonListeners(); // Clear any listeners applied from other views
         }
 
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
         Step step = model.currentTask().getCurrentStep().getStep();
 
         if (step.getSubType() == StepSubType.ROTATE_BITS) {

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/ShaOneView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/ShaOneView.java
@@ -13,15 +13,10 @@ package edu.regis.shatu.view;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import java.awt.GridBagConstraints;
-import java.awt.Insets;
 import java.awt.event.ActionListener;
-import java.awt.event.KeyEvent;
-
-import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JTextField;
-
 import edu.regis.shatu.model.StepCompletion;
 import javax.swing.JRadioButton;
 import edu.regis.shatu.model.aol.ShaOneViewStep;
@@ -60,8 +55,6 @@ public class ShaOneView extends UserRequestView { //implements KeyListener
     private JLabel exampleInputLabel;
     private JLabel problem;
     private JTextField answerField;
-    private JButton nextQuestionButton;
-    private boolean checkHintEnabled = false;
 
     /**
      * Label describing the A operand for the function
@@ -297,6 +290,11 @@ public class ShaOneView extends UserRequestView { //implements KeyListener
         questionPanel.addc(operandALabel, 0, 3, 1, 1, 0.0, 0.0,
                 GridBagConstraints.CENTER, GridBagConstraints.NONE,
                 5, 5, 5, 5);
+        
+                
+        addc(buttonPanel, 0, 4, 1, 1, 0.0, 0.0,
+                GridBagConstraints.CENTER, GridBagConstraints.NONE,
+                5, 5, 5, 5);
     }
 
     /**
@@ -396,13 +394,9 @@ public class ShaOneView extends UserRequestView { //implements KeyListener
     @Override
     protected void updatePracticeView() {
 
-        //hintButton = view.getHintButton();
-        //checkButton = view.getCheckButton();
-        nextQuestionButton = view.getNewExampleButton();
-
         // If check and hint buttons are disabled, reset listenerers and apply those used by this view
         if(!checkHintEnabled) {
-            view.resetButtonListeners(); // Clear any listeners applied from other views
+            resetButtonListeners(); // Clear any listeners applied from other views
         }
     }
 

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/ShaZeroView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/ShaZeroView.java
@@ -11,22 +11,15 @@
 package edu.regis.shatu.view;
 
 import java.awt.*;
-import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
-
 import javax.swing.*;
-
 import edu.regis.shatu.model.ShaZeroStep;
 import edu.regis.shatu.model.Step;
 import edu.regis.shatu.model.StepCompletion;
 import edu.regis.shatu.model.aol.NewExampleRequest;
 import edu.regis.shatu.model.aol.ProblemType;
-import edu.regis.shatu.model.aol.RotateStep;
-import edu.regis.shatu.view.act.HintAction;
-import edu.regis.shatu.view.act.NewExampleAction;
-import edu.regis.shatu.view.act.StepCompletionAction;
 
 /**
  * ShaZero class represents the GUI view for performing the SHA Σ₀ function,
@@ -69,7 +62,6 @@ public class ShaZeroView extends UserRequestView implements KeyListener {
      */
     private JTextField answerField;
 
-    private boolean checkHintEnabled = false;
     /**
      * The area in which the Sigma0 function is described
      */
@@ -166,17 +158,7 @@ public class ShaZeroView extends UserRequestView implements KeyListener {
         StepCompletion step = new StepCompletion(currentStep, gson.toJson(example));
 
         step.setStep(currentStep);
-        
-        // Add exampleInputLabel centered
-
-
-//        addc(exampleInputLabel, 0, 0, 2, 1, 0.0, 0.0,
-//                GridBagConstraints.CENTER, GridBagConstraints.NONE,
-//                5, 5, 5, 5);
-        // Add answerField to the layout, centered
-//        addc(answerField, 0, 1, 1, 1, 1.0, 0.0,
-//                GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL,
-//                5, 5, 5, 5);
+     
        
        return step;
 
@@ -332,6 +314,10 @@ public class ShaZeroView extends UserRequestView implements KeyListener {
 
         descriptionPanel.addc(questionPanel, 0, 2, 1, 1, 0.0, 0.0,
                 GridBagConstraints.SOUTHWEST, GridBagConstraints.NONE,
+                5, 5, 5, 5);
+        
+        addc(buttonPanel, 0, 3, 1, 1, 0.0, 0.0,
+                GridBagConstraints.CENTER, GridBagConstraints.NONE,
                 5, 5, 5, 5);
     }
 
@@ -531,7 +517,7 @@ public class ShaZeroView extends UserRequestView implements KeyListener {
 
         // If check and hint buttons are disabled, reset listenerers and apply those used by this view
         if(!checkHintEnabled) {
-            view.resetButtonListeners(); // Clear any listeners applied from other views
+            resetButtonListeners(); // Clear any listeners applied from other views
 
         }
     }

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/ShiftRightView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/ShiftRightView.java
@@ -17,11 +17,9 @@ import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.GridBagConstraints;
-import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
-
 import javax.swing.ButtonGroup;
 import javax.swing.JButton;
 import javax.swing.JLabel;
@@ -30,19 +28,12 @@ import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-
 import edu.regis.shatu.model.BitShiftStep;
 import edu.regis.shatu.model.Step;
 import edu.regis.shatu.model.StepCompletion;
 import edu.regis.shatu.model.aol.NewExampleRequest;
 import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.aol.StepSubType;
-import edu.regis.shatu.view.act.HintAction;
-import edu.regis.shatu.view.act.NewExampleAction;
-import edu.regis.shatu.view.act.StepCompletionAction;
 
 /**
  * ShiftRightView class represents the GUI view for performing the right shift operation on a binary number.
@@ -64,8 +55,7 @@ public class ShiftRightView extends UserRequestView implements KeyListener {
     private JScrollPane responsePane;
     private GPanel questionPanel, descriptionPanel, feedbackPanel, qrPanel;
     private JPanel radioButtonPanel;
-    private JButton checkButton, nextButton, hintButton;
-    private boolean checkHintEnabled = false;
+
     private ButtonGroup problemSizeGroup;
     private JRadioButton fourRadioButton, eightRadioButton, sixteenRadioButton,
             thirtytwoRadioButton;
@@ -126,6 +116,10 @@ public class ShiftRightView extends UserRequestView implements KeyListener {
 
         addc(qrPanel, 0, 2, 3, 1, 1.0, 1.0,
                 GridBagConstraints.NORTHWEST, GridBagConstraints.NONE,
+                5, 5, 5, 5);
+        
+        addc(buttonPanel, 0, 4, 1, 1, 0.0, 0.0,
+                GridBagConstraints.CENTER, GridBagConstraints.NONE,
                 5, 5, 5, 5);
     }
     
@@ -328,22 +322,14 @@ public class ShiftRightView extends UserRequestView implements KeyListener {
      */
     @Override
     protected void updatePracticeView() {
-
-        hintButton = view.getHintButton();
-        checkButton = view.getCheckButton();
-        nextButton = view.getNewExampleButton();
-
-
         responseTextArea.setText("");
         feedbackTextArea.setText("");
 
 
         // If check and hint buttons are disabled, reset listenerers and apply those used by this view
         if(!checkHintEnabled) {
-            view.resetButtonListeners(); // Clear any listeners applied from other views
+            resetButtonListeners(); // Clear any listeners applied from other views
         }
-
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
         Step step = model.currentTask().getCurrentStep().getStep();
         System.out.println("Current Step: " + step.getSubType());

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/TutoringSessionView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/TutoringSessionView.java
@@ -14,9 +14,6 @@ package edu.regis.shatu.view;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.event.ActionListener;
-
-import javax.swing.Action;
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JPanel;
@@ -28,9 +25,6 @@ import edu.regis.shatu.model.aol.PendingStep;
 import edu.regis.shatu.model.aol.PendingTask;
 import edu.regis.shatu.model.aol.StepSubType;
 import edu.regis.shatu.model.aol.ViewType;
-import edu.regis.shatu.view.act.HintAction;
-import edu.regis.shatu.view.act.NewExampleAction;
-import edu.regis.shatu.view.act.StepCompletionAction;
 
 
 /**
@@ -49,11 +43,6 @@ public class TutoringSessionView extends GPanel {
      * Universal button for returning to the dashboard.
      */
     private JButton dashboardButton;
-    
-    /**
-     * Universal 'Check', 'New Example', 'Hint' buttons.
-     */
-    private JButton checkButton, newExampleButton, hintButton;
     
     /*
      * Universal button for logging off. 
@@ -84,11 +73,6 @@ public class TutoringSessionView extends GPanel {
      * The container for the StepView
      */
     private JPanel stepViewContainer;
-
-    /**
-     * The Panel for each view's buttons to sit in
-     */
-    private JPanel buttonPanel;
 
     /**
      * The Split Pane to split step and main view panes
@@ -140,7 +124,6 @@ public class TutoringSessionView extends GPanel {
      * Set up the Practice View screen
      */
     private void setupPracticeView() {
-        initializePracticeComponents();
         layoutPracticeComponents();
     }
 
@@ -221,7 +204,7 @@ public class TutoringSessionView extends GPanel {
         stepViewContainer = new JPanel(new BorderLayout());
 
         // Create a button panel for Check and Hint buttons
-        buttonPanel = new JPanel(); // Default FlowLayout
+       // buttonPanel = new JPanel(); // Default FlowLayout
 
         // Create a JSplitPane to allow resizing of the left panel
         splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, scrollPane, stepViewContainer);
@@ -244,8 +227,6 @@ public class TutoringSessionView extends GPanel {
 
         stepViewContainer.add(stepView, BorderLayout.CENTER);
 
-        buttonPanel.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10)); // Add padding
-
         splitPane.setDividerLocation(259); // Initial width of the left panel in pixels
         splitPane.setOneTouchExpandable(true); // Allow collapsing and expanding by the user
 
@@ -260,30 +241,17 @@ public class TutoringSessionView extends GPanel {
     }
 
     /**
-     * Create the child GUI components appearing in this frame.
-     */
-    private void initializePracticeComponents() {
-        
-        checkButton = this.initializeButton(StepCompletionAction.instance());
-        hintButton = this.initializeButton(HintAction.instance());
-        newExampleButton = this.initializeButton(NewExampleAction.instance());
-        newExampleButton.addActionListener(e -> {
-            checkButton.setEnabled(true);
-            hintButton.setEnabled(true);
-        });
-    }
-    /**
     * Layout the child components in this view
     */
    private void layoutPracticeComponents() {
 
        // Add buttons to the button panel
-       buttonPanel.add(checkButton);
-       buttonPanel.add(newExampleButton);
-       buttonPanel.add(hintButton);
+     //  buttonPanel.add(checkButton);
+     //  buttonPanel.add(newExampleButton);
+      // buttonPanel.add(hintButton);
 
        // Add the button panel to the bottom of the stepViewContainer
-       stepViewContainer.add(buttonPanel, BorderLayout.SOUTH);
+     //  stepViewContainer.add(buttonPanel, BorderLayout.SOUTH);
    }
 
     /**
@@ -297,11 +265,11 @@ public class TutoringSessionView extends GPanel {
      * Set up the layout for Teach Me View components
      */
    private void layoutTeachComponents() {
-       buttonPanel.removeAll();
+      // buttonPanel.removeAll();
        stepViewContainer.removeAll();
 
        // Add the button panel to the bottom of the stepViewContainer
-       stepViewContainer.add(buttonPanel, BorderLayout.SOUTH);
+      // stepViewContainer.add(buttonPanel, BorderLayout.SOUTH);
 
 
        //TODO: Layout Teach Me View specific components here
@@ -318,36 +286,16 @@ public class TutoringSessionView extends GPanel {
      * Set up the layout for Quiz Me View components
      */
     private void layoutQuizComponents() {
-        buttonPanel.removeAll();
+       // buttonPanel.removeAll();
         stepViewContainer.removeAll();
 
         // Add the button panel to the bottom of the stepViewContainer
-        stepViewContainer.add(buttonPanel, BorderLayout.SOUTH);
+       // stepViewContainer.add(buttonPanel, BorderLayout.SOUTH);
 
 
         //TODO: Layout Teach Me View specific components here
     }
-   
-   /**
-     * Initializes the universal StepView buttons requiring Strings.
-     * Initializing these buttons via this method aids in consistency.
-     * @param buttonText the text to display within the button.
-     * @return an initialized button according to the button type.
-     */
-    public JButton initializeButton(String buttonText){
-            return new JButton(buttonText);
-    }
-    
-    /**
-     * Initializes the universal StepView buttons requiring actions.
-     * Initializing these buttons via this method aids in consistency.
-     * @param buttonInstance the text to display within the button.
-     * @return an initialized button according to the button type.
-     */
-    public JButton initializeButton(Action buttonInstance){
-            return new JButton(buttonInstance);
-    }
-    
+
     /**
      * Toggles the given button on/off
      * Ensures the GUI updates to display the button's new state
@@ -357,69 +305,8 @@ public class TutoringSessionView extends GPanel {
         button.repaint();
         button.revalidate();
     }
-    
-    /**
-     * These buttons are used universally by each view
-     * Each view attaches its own listeners, and must be cleaned up
-     * before interacting with a new view.
-     * 
-     * Failure to clean up the additional listeners will result in unnecessary,
-     * or redundant, operations executed.
-     */
-    public void resetButtonListeners() {
-        // Keep track of the known initial listeners
-        ActionListener hintAction = HintAction.instance();
-        ActionListener checkAction = StepCompletionAction.instance();
-        ActionListener newExampleAction = NewExampleAction.instance();
 
-        // Clear all listeners for the check button and re-add the known listener
-        for (ActionListener listener : checkButton.getActionListeners()) {
-            checkButton.removeActionListener(listener);
-        }
-        checkButton.addActionListener(checkAction);
-
-        // Clear all listeners for the hint button and re-add the known listener
-        for (ActionListener listener : hintButton.getActionListeners()) {
-            hintButton.removeActionListener(listener);
-        }
-        hintButton.addActionListener(hintAction);
-
-        // Clear all listeners for the new example button and re-add the known listeners
-        for (ActionListener listener : newExampleButton.getActionListeners()) {
-            newExampleButton.removeActionListener(listener);
-        }
-        newExampleButton.addActionListener(newExampleAction);
-        newExampleButton.addActionListener(e -> {
-            checkButton.setEnabled(true);
-            hintButton.setEnabled(true);
-        }); // Re-add the lambda listener
-
-        // Reset button text
-        checkButton.setText("Check");
-        hintButton.setText("Hint");
-        newExampleButton.setText("New Example");
-
-        // Set the default button states
-        checkButton.setEnabled(false);
-        hintButton.setEnabled(false);
-        newExampleButton.setEnabled(true); // Enable New Example by default
-    }
-   
-    public JButton getCheckButton() {
-        return checkButton;
-    }
-    
-    public JButton getNewExampleButton(){
-        newExampleButton.setEnabled(true);
-        return newExampleButton;
-    }
-
-    public JButton getHintButton() {
-        return hintButton;
-    }
-
-    public ViewType getCurrentViewType()
-    {
+    public ViewType getCurrentViewType() {
         return this.currentViewType;
     }
     

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/UserRequestView.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/UserRequestView.java
@@ -21,6 +21,13 @@ import edu.regis.shatu.model.StepCompletion;
 import edu.regis.shatu.model.TutoringSession;
 import edu.regis.shatu.model.aol.NewExampleRequest;
 import edu.regis.shatu.model.aol.PendingTask;
+import edu.regis.shatu.view.act.HintAction;
+import edu.regis.shatu.view.act.NewExampleAction;
+import edu.regis.shatu.view.act.StepCompletionAction;
+import java.awt.GridBagConstraints;
+import java.awt.event.ActionListener;
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
 
 /**
  * A abstract view that supports various user gestures that results in a request 
@@ -38,6 +45,18 @@ public abstract class UserRequestView extends GPanel {
      * view.
      */
     protected TutoringSession model;
+    
+    /**
+     * Universal 'Check', 'New Example', 'Hint' buttons.
+     */
+    protected JButton checkButton, newExampleButton, hintButton;
+    
+    protected boolean checkHintEnabled = false;
+    
+    /**
+     * The Panel for each view's buttons to sit in
+     */
+    protected GPanel buttonPanel;
    
     /**
      * Convenience utility for converting between Java and JSon objects.
@@ -88,6 +107,11 @@ public abstract class UserRequestView extends GPanel {
      * @return StepCompletion
      */
     public abstract StepCompletion stepCompletion();
+    
+    public UserRequestView() {
+        initializePracticeButtons();
+        createButtonPanel();
+    }
 
     public TutoringSession getModel() {
         return this.model;
@@ -109,4 +133,97 @@ public abstract class UserRequestView extends GPanel {
        model.addCurrentTask(task);
        updateView();
     }
+    
+      /**
+     * Create the child GUI components appearing in this frame.
+     */
+    private void initializePracticeButtons() {
+        checkButton = new JButton(StepCompletionAction.instance());
+        hintButton = new JButton(HintAction.instance());
+        newExampleButton = new JButton (NewExampleAction.instance());
+        
+        newExampleButton.addActionListener(e -> {
+            checkButton.setEnabled(true);
+            hintButton.setEnabled(true);
+        });
+    }
+    
+    private void createButtonPanel() {
+        buttonPanel = new GPanel();
+        buttonPanel.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10)); // Add padding
+       
+        buttonPanel.addc(newExampleButton, 0, 0, 1, 1, 1.0, 1.0,
+                GridBagConstraints.NORTHWEST, GridBagConstraints.NONE,
+                5, 5, 5, 5);
+       
+        buttonPanel.addc(checkButton, 1, 0, 1, 1, 1.0, 1.0,
+                GridBagConstraints.NORTHWEST, GridBagConstraints.NONE,
+                5, 5, 5, 5);
+        
+        buttonPanel.addc(hintButton, 2, 0, 1, 1, 1.0, 1.0,
+                GridBagConstraints.NORTHWEST, GridBagConstraints.NONE,
+                5, 5, 5, 5);
+    }
+    
+     /**
+     * These buttons are used universally by each view
+     * Each view attaches its own listeners, and must be cleaned up
+     * before interacting with a new view.
+     * 
+     * Failure to clean up the additional listeners will result in unnecessary,
+     * or redundant, operations executed.
+     */
+    public void resetButtonListeners() {
+        // Keep track of the known initial listeners
+        ActionListener hintAction = HintAction.instance();
+        ActionListener checkAction = StepCompletionAction.instance();
+        ActionListener newExampleAction = NewExampleAction.instance();
+
+        // Clear all listeners for the check button and re-add the known listener
+        for (ActionListener listener : checkButton.getActionListeners()) {
+            checkButton.removeActionListener(listener);
+        }
+        checkButton.addActionListener(checkAction);
+
+        // Clear all listeners for the hint button and re-add the known listener
+        for (ActionListener listener : hintButton.getActionListeners()) {
+            hintButton.removeActionListener(listener);
+        }
+        hintButton.addActionListener(hintAction);
+
+        // Clear all listeners for the new example button and re-add the known listeners
+        for (ActionListener listener : newExampleButton.getActionListeners()) {
+            newExampleButton.removeActionListener(listener);
+        }
+        newExampleButton.addActionListener(newExampleAction);
+        newExampleButton.addActionListener(e -> {
+            checkButton.setEnabled(true);
+            hintButton.setEnabled(true);
+        }); // Re-add the lambda listener
+
+        // Reset button text
+        checkButton.setText("Check");
+        hintButton.setText("Hint");
+        newExampleButton.setText("New Example");
+
+        // Set the default button states
+        checkButton.setEnabled(false);
+        hintButton.setEnabled(false);
+        newExampleButton.setEnabled(true); // Enable New Example by default
+    }
+    
+    /*
+     public JButton getCheckButton() {
+        return checkButton;
+    }
+    
+    public JButton getNewExampleButton(){
+        newExampleButton.setEnabled(true);
+        return newExampleButton;
+    }
+
+    public JButton getHintButton() {
+        return hintButton;
+    }
+    */
 }

--- a/ShaTuApp/src/main/java/edu/regis/shatu/view/act/NewExampleAction.java
+++ b/ShaTuApp/src/main/java/edu/regis/shatu/view/act/NewExampleAction.java
@@ -35,7 +35,7 @@ import edu.regis.shatu.view.UserRequestView;
 /**
  * An (MVC) controller handling a GUI gesture representing a user's request for
  * a new problem to solve via selecting a new panel or requesting a new example
- * directly. A client request for a new example is sent to the tutor who will 
+ * directly. A client request for a new example is sent to the tutor who will
  * reply with the new Task and Step to be completed along with their associated
  * data.
  *
@@ -88,7 +88,7 @@ public class NewExampleAction extends ShaTuGuiAction {
     /**
      * Handle the user's request for a new example by sending it to the tutor.
      *
-     * If successful, the current view is updated with the contents of the new 
+     * If successful, the current view is updated with the contents of the new
      * example (and associated task) in the reply from the tutor.
      *
      * @param evt ignored
@@ -97,44 +97,41 @@ public class NewExampleAction extends ShaTuGuiAction {
     public void actionPerformed(ActionEvent evt) {
         System.out.println("actionPerformed");
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        
 
-        System.out.println("Here1");
         Account account = SplashFrame.instance().getAccount();
-        System.out.println("Here2");
+
         //Catches a possible IllegalArgumentException thrown by the 
-        try{
-            System.out.println("Here3");
-           //Get the view that originated the NewExampleRequest
-           UserRequestView exView = GuiController.instance().getStepView().getUserRequestView();
-            System.out.println("Get view: " + exView);
-           //Call the overridden newRequest() method to generate an appropriate
-           //request to the tutor based on the current view
-           NewExampleRequest ex = exView.newRequest();
-            System.out.println("after new request: " + ex);
-           //Construct the request with the users data and NewExampleRequest
-           //returned by the newRequest() method
-           ClientRequest request = new ClientRequest(ServerRequestType.NEW_EXAMPLE);
-           request.setUserId(account.getUserId());
-           request.setSecurityToken(MainFrame.instance().getModel().getSecurityToken());
-           request.setData(gson.toJson(ex));
-           //Send the request to the tutor and save the reply
-           TutorReply reply = SvcFacade.instance().tutorRequest(request);
-        switch (reply.getStatus()) {
-            case ":ERR":
-                // If we get here, there is a coding error in the tutor svc
-                System.out.println("Coding error  status: " + reply.getStatus());
-                break;
-            default:
-                System.out.println("got a reply");
-               //If the status was not an error, we can update the model and the
-               //view with the new task sent by the tutor
-                
-                exView.setCurrentTask(gson.fromJson(reply.getData(), PendingTask.class)); 
-             //  exView.setCurrentTask(gson.fromJson(reply.getData(), Task.class)); 
+        try {
+            //Get the view that originated the NewExampleRequest
+            UserRequestView exView = GuiController.instance().getStepView().getUserRequestView();
+
+            //Call the overridden newRequest() method to generate an appropriate
+            //request to the tutor based on the current view
+            NewExampleRequest ex = exView.newRequest();
+
+            //Construct the request with the users data and NewExampleRequest
+            //returned by the newRequest() method
+            ClientRequest request = new ClientRequest(ServerRequestType.NEW_EXAMPLE);
+            request.setUserId(account.getUserId());
+            request.setSecurityToken(MainFrame.instance().getModel().getSecurityToken());
+            request.setData(gson.toJson(ex));
+            
+            //Send the request to the tutor and save the reply
+            TutorReply reply = SvcFacade.instance().tutorRequest(request);
+
+            switch (reply.getStatus()) {
+                case ":ERR":
+                    // If we get here, there is a coding error in the tutor svc
+                    System.out.println("Coding error  status: " + reply.getStatus());
+                    break;
+                default:
+                    //If the status was not an error, we can update the model and the
+                    //view with the new task sent by the tutor
+
+                    exView.setCurrentTask(gson.fromJson(reply.getData(), PendingTask.class));
             }
-        }catch(IllegalArgException e){
-           System.out.println("Illegal arg exception " + e);
+        } catch (IllegalArgException e) {
+            System.out.println("Illegal arg exception " + e);
         }
     }
 }


### PR DESCRIPTION
A major update that refactored and fixed bugs in the tutor's new Objective approach.
  Refactor
     Moved New Example, Check, and Hint Buttons from TutoringSessionView to UserRequestView
     Updated UserRequestView subclass views to utilize the new approach
        Included removing redundant local button fields
        PrepareSchedule had two sets of buttons, fixed
  InitiVarView fixed text field widths

 ShaTuTutor
    Updated the newExample, completeStep, and requestHint to appropriate use the new Objective approach

 Testing
    ChoiceFunctionView "works" for new example, check, and hint (though student modeling is probably not incorporated
    Checked that all views are back to where they were (which doesn't mean they all work, but many do)
