### PR TITLE
Gson in Actions

### DIFF
--- a/src/main/java/edu/regis/shatu/view/act/CheckSecurityQuestAction.java
+++ b/src/main/java/edu/regis/shatu/view/act/CheckSecurityQuestAction.java
@@ -78,7 +78,7 @@ public class CheckSecurityQuestAction extends ShaTuGuiAction {
      */
     @Override
     public void actionPerformed(ActionEvent evt) { 
-        Gson gson = new Gson();
+        Gson gson = getGson();
         
         MainFrame frame = MainFrame.instance();
         Account account = frame.getAccount();

--- a/src/main/java/edu/regis/shatu/view/act/CreateAcctAction.java
+++ b/src/main/java/edu/regis/shatu/view/act/CreateAcctAction.java
@@ -82,7 +82,7 @@ public class CreateAcctAction extends ShaTuGuiAction {
      */
     @Override
     public void actionPerformed(ActionEvent evt) {
-        Gson gson = new Gson();
+        Gson gson = getGson();
         
         MainFrame frame = MainFrame.instance();
         

--- a/src/main/java/edu/regis/shatu/view/act/HintAction.java
+++ b/src/main/java/edu/regis/shatu/view/act/HintAction.java
@@ -96,7 +96,7 @@ public class HintAction extends ShaTuGuiAction {
      */
     @Override
     public void actionPerformed(ActionEvent evt) {
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        Gson gson = getGsonPretty();
 
         Account account = MainFrame.instance().getAccount();
 

--- a/src/main/java/edu/regis/shatu/view/act/NewExampleAction.java
+++ b/src/main/java/edu/regis/shatu/view/act/NewExampleAction.java
@@ -95,7 +95,7 @@ public class NewExampleAction extends ShaTuGuiAction {
     @Override
     public void actionPerformed(ActionEvent evt) {
         System.out.println("actionPerformed");
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        Gson gson = getGsonPretty();
 
         Account account = MainFrame.instance().getAccount();
 

--- a/src/main/java/edu/regis/shatu/view/act/ResetPasswordAction.java
+++ b/src/main/java/edu/regis/shatu/view/act/ResetPasswordAction.java
@@ -76,7 +76,7 @@ public class ResetPasswordAction extends ShaTuGuiAction {
      */
     @Override
     public void actionPerformed(ActionEvent evt) {
-        Gson gson = new Gson();
+        Gson gson = getGson();
         
         MainFrame mainFrame = MainFrame.instance();
         
@@ -87,7 +87,7 @@ public class ResetPasswordAction extends ShaTuGuiAction {
         ClientRequest request = new ClientRequest(ServerRequestType.RESET_PASSWORD);
         request.setUserId(account.getUserId());
         request.setSecurityToken(token);
-        request.setData(new Gson().toJson(account));
+        request.setData(gson.toJson(account));
 
         request.setUserId(account.getUserId()); //required for session tracking
         request.setData(gson.toJson(account));

--- a/src/main/java/edu/regis/shatu/view/act/ShaTuGuiAction.java
+++ b/src/main/java/edu/regis/shatu/view/act/ShaTuGuiAction.java
@@ -17,6 +17,9 @@ import java.awt.Image;
 import javax.swing.AbstractAction;
 import javax.swing.ImageIcon;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
 import edu.regis.shatu.util.ImgFactory;
 
 /**
@@ -27,6 +30,9 @@ import edu.regis.shatu.util.ImgFactory;
  * @author rickb
  */
 public abstract class ShaTuGuiAction extends AbstractAction {
+    private static final Gson gson = new Gson();
+    private static final Gson gsonPretty = new GsonBuilder().setPrettyPrinting().create();
+
     public ShaTuGuiAction(String name) {
         super(name);
     }
@@ -44,5 +50,27 @@ public abstract class ShaTuGuiAction extends AbstractAction {
         // ToDo: Better error reporting
         Image img = ImgFactory.createImage(imageFileName);
         return new ImageIcon(img, altText);
+    }
+    
+    /**
+     * Return the normal Gson instance
+     * 
+     * This instance is used by ResetPasswordAction, CreateAcctAction, and CheckSecurityQuestAction
+     *
+     * @return gson = new Gson()
+     */
+    protected static final Gson getGson() {
+        return gson;
+    }
+
+    /**
+     * Return the pretty Gson instance
+     * 
+     * This instance is used by SignInAction, StepCompletionAction, NewExampleAction, and HintAction
+     *
+     * @return gsonPretty = new GsonBuilder().setPrettyPrinting().create()
+     */
+    protected static final Gson getGsonPretty() {
+        return gsonPretty;
     }
 }

--- a/src/main/java/edu/regis/shatu/view/act/SignInAction.java
+++ b/src/main/java/edu/regis/shatu/view/act/SignInAction.java
@@ -92,7 +92,7 @@ public class SignInAction extends ShaTuGuiAction {
      */
     @Override
     public void actionPerformed(ActionEvent evt) {
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        Gson gson = getGsonPretty();
         Account account = MainFrame.instance().getAccount();
         
         ClientRequest request = new ClientRequest(ServerRequestType.SIGN_IN);

--- a/src/main/java/edu/regis/shatu/view/act/StepCompletionAction.java
+++ b/src/main/java/edu/regis/shatu/view/act/StepCompletionAction.java
@@ -104,7 +104,7 @@ public class StepCompletionAction extends ShaTuGuiAction {
      */
     @Override
     public void actionPerformed(ActionEvent evt) {
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        Gson gson = getGsonPretty();
         Account account = MainFrame.instance().getAccount();
         // Catches a possible IllegalArgumentException thrown by the
         // getUserRequestView() method


### PR DESCRIPTION
Replaced all new Gson or new GsonBuilder calls in child classes with shared static instances in ShaTuGuiAction.

Added two static getters in ShaTuGuiAction:

getGson() – normal Gson instance (used by SignInAction, StepCompletionAction, NewExampleAction).

getGsonPretty() – pretty-print Gson instance (used by ResetPasswordAction, CreateAcctAction, CheckSecurityQuestAction, HintAction).

Updated actionPerformed methods in all child classes to use the shared Gson instances via getGson() or getGsonPretty().