### PR TITLE
SHAT-327: Implement SEE_ONE mode UI controls and auto-login

### DIFF
--- a/src/main/java/edu/regis/shatu/model/TutoringSession.java
+++ b/src/main/java/edu/regis/shatu/model/TutoringSession.java
@@ -144,6 +144,16 @@ public class TutoringSession {
         this.isActive = isActive;
     }
 
+    
+    public TutoringMode getTutoringMode() {
+    return tutoringMode;
+    }
+
+    public void setTutoringMode(TutoringMode tutoringMode) {
+        this.tutoringMode = tutoringMode;
+    }
+    
+    
     public GregorianCalendar getStartDate() {
         return startDate;
     }
@@ -183,10 +193,9 @@ public class TutoringSession {
     public void removeTask(PendingTask task) {
         tasks.remove(task);
     }
-    
+    //Updated method to remove task by taskId to prevent ConcurrentModificationException
+
     public void removeTask(int taskId) {
-        for (PendingTask pendingTask : tasks) 
-            if (pendingTask.getTask().getId() == taskId)
-                removeTask(pendingTask);
+        tasks.removeIf(pendingTask -> pendingTask.getTask().getId() == taskId);
     }
 }

--- a/src/main/java/edu/regis/shatu/svc/ShaTuTutor.java
+++ b/src/main/java/edu/regis/shatu/svc/ShaTuTutor.java
@@ -42,23 +42,9 @@ import edu.regis.shatu.model.aol.Problem;
 import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.aol.StepSubType;
 import edu.regis.shatu.model.aol.StudentModel;
+import edu.regis.shatu.model.aol.TutoringMode;
 import edu.regis.shatu.model.steps.Step;
-import edu.regis.shatu.objectives.AddBits;
-import edu.regis.shatu.objectives.AddMsgLen;
-import edu.regis.shatu.objectives.AddOne;
-import edu.regis.shatu.objectives.ChoiceFunction;
-import edu.regis.shatu.objectives.CompressRound;
-import edu.regis.shatu.objectives.EncodeAscii;
-import edu.regis.shatu.objectives.InitVars;
-import edu.regis.shatu.objectives.MajorityFunction;
-import edu.regis.shatu.objectives.Objective;
-import edu.regis.shatu.objectives.PadZeros;
-import edu.regis.shatu.objectives.PrepareSchedule;
-import edu.regis.shatu.objectives.RotateBits;
-import edu.regis.shatu.objectives.ShaOne;
-import edu.regis.shatu.objectives.ShaZero;
-import edu.regis.shatu.objectives.ShiftBits;
-import edu.regis.shatu.objectives.XorBits;
+import edu.regis.shatu.objectives.*;
 
 /**
  * The ShaTu tutor, which implements the tutoring service.
@@ -656,6 +642,10 @@ public class ShaTuTutor implements TutorSvc {
         tSession.setCourse(course.getDigest());
         tSession.setUnit(course.currentUnit().getDigest());
 
+        //set tutoringmode to SEE_ONE or Unit 0
+        tSession.setTutoringMode(TutoringMode.SEE_ONE);
+        
+        
         Task task = getFirstTask(course);
         PendingTask pendingTask = new PendingTask(task);
         pendingTask.setCurrentStep(new PendingStep(task.getCurrentStep()));

--- a/src/main/java/edu/regis/shatu/view/Add1View.java
+++ b/src/main/java/edu/regis/shatu/view/Add1View.java
@@ -36,6 +36,7 @@ import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.aol.StepSubType;
 import edu.regis.shatu.model.steps.AddOneStep;
 import edu.regis.shatu.model.steps.Step;
+import edu.regis.shatu.model.aol.TutoringMode;
 
 /**
  * A view that requests the student to add a single '1' bit to the byte prompt.
@@ -402,6 +403,31 @@ public class Add1View extends UserRequestView {
         
     }
 
+    /**
+     * Configures UI components based on current tutoring mode
+     * Disables fields not available for SEE_ONE mode for passive viewing.
+     */
+    @Override
+    protected void configureModeSpecificUI() {
+        super.configureModeSpecificUI();//calls parent to handle the buttons
+        
+        if (model == null) {
+            return;
+        }
+        
+        TutoringMode mode = model.getTutoringMode();
+        
+        if (mode == TutoringMode.SEE_ONE) {
+            messageLengthField.setEnabled(false);
+            responseTextArea.setEnabled(false);
+        }
+        // DO_ONE & TEACH_ONE
+        else {
+            messageLengthField.setEnabled(true);
+            responseTextArea.setEnabled(true);
+        }
+    }
+    
     /**
      * This method is suppose to be called when the new example button is
      * clicked, it will assign related data pertaining to this step to the

--- a/src/main/java/edu/regis/shatu/view/AddTwoBitView.java
+++ b/src/main/java/edu/regis/shatu/view/AddTwoBitView.java
@@ -35,6 +35,7 @@ import edu.regis.shatu.model.aol.NewExampleRequest;
 import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.aol.StepSubType;
 import edu.regis.shatu.model.steps.Step;
+import edu.regis.shatu.model.aol.TutoringMode;
 
 /**
  * AddTwoBitView class represents a GUI view for adding two binary numbers
@@ -331,8 +332,31 @@ public class AddTwoBitView extends UserRequestView implements KeyListener {
                 stringLabel2.setText("binary number2: " + binary2);
             }
         }
-        
-    
     }
-
+    
+    /**
+     * Configure UI components based on the current tutoring mode
+     *Disables fields not available for SEE_ONE mode for passive viewing.
+     * 
+     */
+    
+    @Override
+    protected void configureModeSpecificUI() {
+        super.configureModeSpecificUI();//call parent to handle buttons
+        
+        if(model == null) {
+            return;
+        }
+        
+        TutoringMode mode = model.getTutoringMode();
+        
+        if (mode == TutoringMode.SEE_ONE) {
+            responseTextArea.setEnabled(false);
+        }
+        // DO_ONE & TEACH_ONE
+        else {
+            responseTextArea.setEnabled(true);
+        }
+    }
+    
 }

--- a/src/main/java/edu/regis/shatu/view/ChoiceFunctionView.java
+++ b/src/main/java/edu/regis/shatu/view/ChoiceFunctionView.java
@@ -45,6 +45,7 @@ import edu.regis.shatu.model.steps.ChoiceFunctionStep;
 import edu.regis.shatu.model.steps.Step;
 import java.awt.event.KeyAdapter;
 import javax.swing.JOptionPane;
+import edu.regis.shatu.model.aol.TutoringMode;
 
 /**
  * ChoiceFunctionView class represents a GUI view for a choice function Ch(x, y,
@@ -499,5 +500,38 @@ public class ChoiceFunctionView extends UserRequestView implements KeyListener {
         }
        
     }
+    
+    /**
+     * Configure UI components based on the current tutoring mode
+     * Disables fields not available for SEE_ONE mode for passive viewing.
+     * 
+     */
+    
+    @Override
+    protected void configureModeSpecificUI() {
+        super.configureModeSpecificUI();//call parent to handle buttons
+        
+        if(model == null) {
+            return;
+        }
+        
+        TutoringMode mode = model.getTutoringMode();
+        
+        if (mode == TutoringMode.SEE_ONE) {
+            fourRadioButton.setEnabled(false);
+            eightRadioButton.setEnabled(false);
+            sixteenRadioButton.setEnabled(false);
+            thirtytwoRadioButton.setEnabled(false);
+            responseTextArea.setEnabled(false);
+        }
+        // DO_ONE & TEACH_ONE
+        else {
+            fourRadioButton.setEnabled(true);
+            eightRadioButton.setEnabled(true);
+            sixteenRadioButton.setEnabled(true);
+            thirtytwoRadioButton.setEnabled(true);
+            responseTextArea.setEnabled(true);
+        }
+    } 
 
 }

--- a/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
+++ b/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
@@ -27,6 +27,7 @@ import javax.swing.JOptionPane;
 import edu.regis.shatu.model.StepCompletion;
 import edu.regis.shatu.model.aol.NewExampleRequest;
 import edu.regis.shatu.model.aol.ProblemType;
+import edu.regis.shatu.model.aol.TutoringMode;
 import edu.regis.shatu.model.steps.CompressRoundStep;
 import edu.regis.shatu.model.steps.Step;
 import edu.regis.shatu.svc.SHA_256;
@@ -593,6 +594,33 @@ public class CompressionCanvasView extends UserRequestView implements ActionList
         newExampleButton.setEnabled(false);
     
     }
+    
+    /**
+     * Configure UI components based on the current tutoring mode
+     * Disables fields not available for SEE_ONE mode for passive viewing.
+     * 
+     */
+    
+    @Override
+    protected void configureModeSpecificUI() {
+        super.configureModeSpecificUI();//call parent to handle buttons
+        
+        if(model == null) {
+            return;
+        }
+        
+        TutoringMode mode = model.getTutoringMode();
+        
+        if (mode == TutoringMode.SEE_ONE) {
+            nextRoundButton.setEnabled(false);
+            newMessageButton.setEnabled(false);
+        }
+        // DO_ONE & TEACH_ONE
+        else {
+            nextRoundButton.setEnabled(true);
+            newMessageButton.setEnabled(true);
+        }
+    } 
 
 
     // TO DO: not implemented at this time

--- a/src/main/java/edu/regis/shatu/view/EncodeView.java
+++ b/src/main/java/edu/regis/shatu/view/EncodeView.java
@@ -32,6 +32,7 @@ import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.aol.StepSubType;
 import edu.regis.shatu.model.steps.EncodeAsciiStep;
 import edu.regis.shatu.model.steps.Step;
+import edu.regis.shatu.model.aol.TutoringMode;
 
 /**
  * A view that requests the student to add a single '1' bit to the byte prompt.
@@ -396,7 +397,32 @@ public class EncodeView extends UserRequestView {
         System.out.println("UpdateView logic continues...");
     }
 
+    /**
+     * Configure UI components based on the current tutoring mode
+     * Disables fields not available for SEE_ONE mode for passive viewing.
+     */
+    @Override
+    protected void configureModeSpecificUI() {
+        super.configureModeSpecificUI(); // Call parent to handle buttons
+        
+        // Check if model exists
+        if (model == null) {
+            return;
+        }
 
+        TutoringMode mode = model.getTutoringMode();
+
+        if (mode == TutoringMode.SEE_ONE) {
+            messageLengthField.setEnabled(false);
+            setQuestionField.setEnabled(false);
+            responseTextArea.setEnabled(false);
+        } else {
+            // DO_ONE and TEACH_ONE both have enabled the fields
+            messageLengthField.setEnabled(true);
+            setQuestionField.setEnabled(true);
+            responseTextArea.setEnabled(true);
+        }
+    }
 
     /**
      * This method is suppose to be called when the new example button is

--- a/src/main/java/edu/regis/shatu/view/ExclusiveOrView.java
+++ b/src/main/java/edu/regis/shatu/view/ExclusiveOrView.java
@@ -43,6 +43,7 @@ import edu.regis.shatu.model.aol.NewExampleRequest;
 import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.aol.StepSubType;
 import edu.regis.shatu.model.steps.Step;
+import edu.regis.shatu.model.aol.TutoringMode;
 
 /**
  * ExclusiveOrView class represents a GUI view for performing Exclusive OR (XOR)
@@ -496,7 +497,38 @@ public class ExclusiveOrView extends UserRequestView implements KeyListener {
         }
     }
         
+    /**
+     * Configure UI components based on the current tutoring mode
+     * Disables fields not available for SEE_ONE mode for passive viewing.
+     * 
+     */
+    
+    @Override
+    protected void configureModeSpecificUI() {
+        super.configureModeSpecificUI();//call parent to handle buttons
         
+        if(model == null) {
+            return;
+        }
+        
+        TutoringMode mode = model.getTutoringMode();
+        
+        if (mode == TutoringMode.SEE_ONE) {
+            fourRadioButton.setEnabled(false);
+            eightRadioButton.setEnabled(false);
+            sixteenRadioButton.setEnabled(false);
+            thirtytwoRadioButton.setEnabled(false);
+            responseTextArea.setEnabled(false);
+        }
+        // DO_ONE & TEACH_ONE
+        else {
+            fourRadioButton.setEnabled(true);
+            eightRadioButton.setEnabled(true);
+            sixteenRadioButton.setEnabled(true);
+            thirtytwoRadioButton.setEnabled(true);
+            responseTextArea.setEnabled(true);
+        }
+    }    
        
     @Override
     public NewExampleRequest newRequest() {

--- a/src/main/java/edu/regis/shatu/view/HighlightLabel.java
+++ b/src/main/java/edu/regis/shatu/view/HighlightLabel.java
@@ -76,7 +76,14 @@ public class HighlightLabel extends JLabel implements MouseListener {
     private String viewName;
     
     private boolean isSelected;
-
+    
+    
+    /**
+     * When disabled, the label will not respond to mouse clicks or show hover effects
+     */
+    private boolean isEnabled = true;
+    
+    
     /**
      * Initialize this label with the given text and a size that was determined
      * empirically.
@@ -122,9 +129,41 @@ public class HighlightLabel extends JLabel implements MouseListener {
         setBackground(NORMAL_BACKGROUND);
         setBorder(NORMAL_BORDER);
     }
+    
+    /**
+     * Set whether this label is enables and can respond to user interactions.
+     * @param enabled true to enable interactions, false to disable
+     */
+    @Override
+    public void setEnabled(boolean enabled) {
+        this.isEnabled = enabled;
+        
+        //update visual appearance based on enabled status
+        if(enabled) {
+            setForeground(Color.BLACK);//restore normal text color
+        } else{
+            setForeground(Color.GRAY); //gray out to show its disabled
+        }
+        
+    }
+    
+    
+    /**
+     * Check if label is currently enabled.
+     * @return true if enabled, false if disabled
+     */
+    @Override
+    public boolean isEnabled() {
+        return isEnabled;
+    }
 
     @Override
     public void mouseClicked(MouseEvent evt) {
+        //Do not respond to clicks if label is disabled
+        if(!isEnabled()) {
+            return;
+        }
+        
         if (!isSelected) {
             select();
         }
@@ -145,6 +184,11 @@ public class HighlightLabel extends JLabel implements MouseListener {
      */
     @Override
     public void mouseEntered(MouseEvent e) {
+        //Don't show hover effects if label is disabled
+        if(!isEnabled()) {
+            return;
+        }
+        
         if (!isSelected) {
             setBorder(HIGHLIGHT_BORDER);
             setBackground(HIGHLIGHT_BACKGROUND);
@@ -158,6 +202,11 @@ public class HighlightLabel extends JLabel implements MouseListener {
      */
     @Override
     public void mouseExited(MouseEvent e) {
+        //Don't change the appearance if label is disabled
+        if(!isEnabled()) {
+            return;
+        }
+        
         if (!isSelected) {
             setBorder(NORMAL_BORDER);
             setBackground(NORMAL_BACKGROUND);

--- a/src/main/java/edu/regis/shatu/view/InitVarView.java
+++ b/src/main/java/edu/regis/shatu/view/InitVarView.java
@@ -25,6 +25,7 @@ import javax.swing.event.DocumentListener;
 import edu.regis.shatu.model.StepCompletion;
 import edu.regis.shatu.model.aol.NewExampleRequest;
 import edu.regis.shatu.model.aol.ProblemType;
+import edu.regis.shatu.model.aol.TutoringMode;
 import edu.regis.shatu.model.steps.InitVarStep;
 import edu.regis.shatu.model.steps.Step;
 
@@ -221,6 +222,45 @@ public class InitVarView extends UserRequestView { // implements ActionListener
         }
       
     }
+    
+    /**
+     * Configure UI components based on the current tutoring mode
+     *Disables fields not available for SEE_ONE mode for passive viewing.
+     * 
+     */
+    
+    @Override
+    protected void configureModeSpecificUI() {
+        super.configureModeSpecificUI();//call parent to handle buttons
+        
+        if(model == null) {
+            return;
+        }
+        
+        TutoringMode mode = model.getTutoringMode();
+        
+        if (mode == TutoringMode.SEE_ONE) {
+            //disable all 8 hash var text fields
+            for (int i = 0; i <NUM_VARS; i++) {
+                hVars[i].setEnabled(false);
+            }
+            
+            //disable feedback area
+            
+            feedbackTextArea.setEnabled(false);
+        }
+        // DO_ONE & TEACH_ONE
+        else {
+            //enable all 8 hash var text fields
+            for (int i = 0; i <NUM_VARS; i++) {
+                hVars[i].setEnabled(false);
+            }
+            
+            //enable feedback area
+            
+            feedbackTextArea.setEnabled(false);
+        }
+    } 
 
     @Override
     public NewExampleRequest newRequest() {

--- a/src/main/java/edu/regis/shatu/view/MajFunctionView.java
+++ b/src/main/java/edu/regis/shatu/view/MajFunctionView.java
@@ -39,6 +39,7 @@ import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.aol.StepSubType;
 import edu.regis.shatu.model.steps.MajorityStep;
 import edu.regis.shatu.model.steps.Step;
+import edu.regis.shatu.model.aol.TutoringMode;
 
 /**
  * This class represents the GUI for the Majority (Maj) function exercise. Given
@@ -638,6 +639,38 @@ public class MajFunctionView extends UserRequestView implements KeyListener {
        
     }
 
+    /**
+     * Configure UI components based on the current tutoring mode
+     * Disables fields not available for SEE_ONE mode for passive viewing.
+     * 
+     */
+    
+    @Override
+    protected void configureModeSpecificUI() {
+        super.configureModeSpecificUI();//call parent to handle buttons
+        
+        if(model == null) {
+            return;
+        }
+        
+        TutoringMode mode = model.getTutoringMode();
+        
+        if (mode == TutoringMode.SEE_ONE) {
+            fourRadioButton.setEnabled(false);
+            eightRadioButton.setEnabled(false);
+            sixteenRadioButton.setEnabled(false);
+            thirtytwoRadioButton.setEnabled(false);
+            responseTextArea.setEnabled(false);
+        }
+        // DO_ONE & TEACH_ONE
+        else {
+            fourRadioButton.setEnabled(true);
+            eightRadioButton.setEnabled(true);
+            sixteenRadioButton.setEnabled(true);
+            thirtytwoRadioButton.setEnabled(true);
+            responseTextArea.setEnabled(true);
+        }
+    } 
 
     /**
      * Sets all fields to default values

--- a/src/main/java/edu/regis/shatu/view/MessageLenView.java
+++ b/src/main/java/edu/regis/shatu/view/MessageLenView.java
@@ -31,6 +31,8 @@ import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.aol.StepSubType;
 import edu.regis.shatu.model.steps.MessageLenStep;
 import edu.regis.shatu.model.steps.Step;
+import edu.regis.shatu.model.aol.TutoringMode;
+
 
 /**
  * A view that requests the student to figure out the number of bits their
@@ -326,6 +328,32 @@ public class MessageLenView extends UserRequestView {
         
    
  
+    }
+    
+    
+    /**
+     * Configures UI components based on current tutoring mode
+     * Disables fields not available for SEE_ONE mode for passive viewing.
+     */
+    @Override
+    protected void configureModeSpecificUI() {
+        super.configureModeSpecificUI();//calls parent to handle the buttons
+        
+        if (model == null) {
+            return;
+        }
+        
+        TutoringMode mode = model.getTutoringMode();
+        
+        if (mode == TutoringMode.SEE_ONE) {
+            messageLengthField.setEnabled(false);
+            responseTextArea.setEnabled(false);
+        }
+        // DO_ONE & TEACH_ONE
+        else {
+            messageLengthField.setEnabled(true);
+            responseTextArea.setEnabled(true);
+        }
     }
 
 

--- a/src/main/java/edu/regis/shatu/view/NewAccountPanel.java
+++ b/src/main/java/edu/regis/shatu/view/NewAccountPanel.java
@@ -64,6 +64,10 @@ public class NewAccountPanel extends GPanel {
      * The account being created and displayed in this panel.
      */
     private Account model;
+    
+    //Background Colors
+    private static final Color REGIS_BLUE = new Color(0, 43, 73);
+    private static final Color REGIS_YELLOW = new Color(241, 196, 0);
 
     /**
      * The editable fields appearing in this dialog.
@@ -82,7 +86,7 @@ public class NewAccountPanel extends GPanel {
     protected JButton signInBut;
     protected JButton createAcctBut;
     protected JButton backBut;
-
+    
     public NewAccountPanel() {
         super();
 
@@ -227,7 +231,7 @@ public class NewAccountPanel extends GPanel {
 
         JLabel copyright = new JLabel("(C) 2019-2025 Johanna and Richard Blumenthal. All Rights Reserved");
         copyright.setFont(new Font("Dialog", Font.PLAIN, 10));
-        copyright.setForeground(new Color(241,196,0));
+        copyright.setForeground(REGIS_YELLOW);
         addc(copyright, 0, 2, 2, 1, 1.0, 1.0,
                 GridBagConstraints.NORTH, GridBagConstraints.CENTER,
                 5, 5, 5, 5);
@@ -241,7 +245,7 @@ public class NewAccountPanel extends GPanel {
 
         JLabel ccis = new JLabel("Regis University Department of Computer and Cyber Sciences");
         ccis.setFont(new Font("Dialog", Font.PLAIN, 20));
-        ccis.setForeground(new Color(0, 43, 73));
+        ccis.setForeground(REGIS_BLUE);
 
         panel.addc(ccis, 0, 0, 1, 1, 1.0, 1.0,
                 GridBagConstraints.NORTHWEST, GridBagConstraints.HORIZONTAL,
@@ -252,7 +256,7 @@ public class NewAccountPanel extends GPanel {
 
     private GPanel createOverview() {
         GPanel panel = new GPanel();
-        panel.setBackground(new Color(241,196,0));
+        panel.setBackground(REGIS_YELLOW);
 
         panel.setSize(300, 400);
         panel.setPreferredSize(new Dimension(300, 400));
@@ -275,7 +279,7 @@ public class NewAccountPanel extends GPanel {
         descr.setEditable(false);
         descr.setLineWrap(true);
         descr.setWrapStyleWord(true);
-        descr.setBackground(new Color(241,196,0));
+        descr.setBackground(REGIS_YELLOW);
         descr.setFont(new Font("Dialog", Font.PLAIN, 12));
 	descr.append("ShaTu provides individualized tutoring practice focused ");
 	descr.append("on understanding the SHA-256 digest algorithm and the");
@@ -305,7 +309,7 @@ public class NewAccountPanel extends GPanel {
 
     private GPanel createLogin() {
         GPanel panel = new GPanel();
-        panel.setBackground(new Color(241,196,0));
+        panel.setBackground(REGIS_YELLOW);
 
         panel.setBorder(BorderFactory.createEmptyBorder(10, 10, 5, 5));
 
@@ -456,7 +460,7 @@ public class NewAccountPanel extends GPanel {
                 break;
             case 2:
                 strength.setText("(Strength: Moderate)");
-                strength.setForeground(new Color(255,255,0));
+                strength.setForeground(Color.YELLOW);
                 break;
             default:
                 strength.setText("(Strength: Good)");

--- a/src/main/java/edu/regis/shatu/view/Pad0View.java
+++ b/src/main/java/edu/regis/shatu/view/Pad0View.java
@@ -35,6 +35,7 @@ import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.aol.StepSubType;
 import edu.regis.shatu.model.steps.Pad0Step;
 import edu.regis.shatu.model.steps.Step;
+import edu.regis.shatu.model.aol.TutoringMode;
 
 /**
  * A view that requests the student to figure out the number of zeros needed to
@@ -388,7 +389,34 @@ public class Pad0View extends UserRequestView {
 
     }
 
-
+    /**
+     * Configure UI components based on the current tutoring mode
+     * Disables fields not available for SEE_ONE mode for passive viewing.
+     * 
+     */
+    
+    @Override
+    protected void configureModeSpecificUI() {
+        super.configureModeSpecificUI();//call parent to handle buttons
+        
+        if(model == null) {
+            return;
+        }
+        
+        TutoringMode mode = model.getTutoringMode();
+        
+        if (mode == TutoringMode.SEE_ONE) {
+            messageLengthField.setEnabled(false);
+            responseTextArea.setEnabled(false);
+        }
+        // DO_ONE & TEACH_ONE
+        else {
+            messageLengthField.setEnabled(true);
+            responseTextArea.setEnabled(true);
+        }
+    }
+    
+    
     /**
      * This method is suppose to be called when the new example button is clicked,
      * it will assign related data pertaining to this step to the related class,

--- a/src/main/java/edu/regis/shatu/view/PrepareScheduleView.java
+++ b/src/main/java/edu/regis/shatu/view/PrepareScheduleView.java
@@ -28,6 +28,7 @@ import javax.swing.SwingConstants;
 import edu.regis.shatu.model.StepCompletion;
 import edu.regis.shatu.model.aol.NewExampleRequest;
 import edu.regis.shatu.model.aol.ProblemType;
+import edu.regis.shatu.model.aol.TutoringMode;
 import edu.regis.shatu.model.steps.Step;
 
 /**
@@ -338,6 +339,42 @@ public class PrepareScheduleView extends UserRequestView { // implements ActionL
       
     }
 
+    
+    
+    /**
+     * Configure UI components based on the current tutoring mode
+     * Disables fields not available for SEE_ONE mode for passive viewing.
+     * 
+     */
+    
+    @Override
+    protected void configureModeSpecificUI() {
+        super.configureModeSpecificUI();//call parent to handle buttons
+        
+        if(model == null) {
+            return;
+        }
+        
+        TutoringMode mode = model.getTutoringMode();
+        
+        if (mode == TutoringMode.SEE_ONE) {
+            answerOptions[0].setEnabled(false);
+            answerOptions[1].setEnabled(false);
+            answerOptions[2].setEnabled(false);
+            
+            //disable feedback label
+            feedbackLabel.setEnabled(false);
+        }
+        // DO_ONE & TEACH_ONE
+        else {
+            answerOptions[0].setEnabled(true);
+            answerOptions[1].setEnabled(true);
+            answerOptions[2].setEnabled(true);
+            
+            feedbackLabel.setEnabled(true);
+        }
+    } 
+    
     /**
      * **Override the abstract newRequest() method from UserRequestView.**
      */

--- a/src/main/java/edu/regis/shatu/view/ResetPasswordPanel.java
+++ b/src/main/java/edu/regis/shatu/view/ResetPasswordPanel.java
@@ -47,6 +47,10 @@ public class ResetPasswordPanel extends GPanel{
     
     private String securityToken;
     
+    //Background Colors
+    private static final Color REGIS_BLUE = new Color(0, 43, 73);
+    private static final Color REGIS_YELLOW = new Color(241, 196, 0);
+    
     public void setSecurityToken(String token) {
         this.securityToken = token;
     }
@@ -187,7 +191,7 @@ public class ResetPasswordPanel extends GPanel{
     }
 
     private void layoutPanel() {
-        setBackground(new Color(0, 43, 73));
+        setBackground(REGIS_BLUE);
 
         setPreferredSize(new Dimension(300, 400));
 
@@ -205,7 +209,7 @@ public class ResetPasswordPanel extends GPanel{
 
         JLabel copyright = new JLabel("(C) 2019-2024 Johanna and Richard Blumenthal. All Rights Reserved");
         copyright.setFont(new Font("Dialog", Font.PLAIN, 10));
-        copyright.setForeground(new Color(241,196,0));
+        copyright.setForeground(REGIS_YELLOW);
         addc(copyright, 0, 2, 2, 1, 1.0, 1.0,
                 GridBagConstraints.NORTH, GridBagConstraints.CENTER,
                 5, 5, 5, 5);
@@ -219,7 +223,7 @@ public class ResetPasswordPanel extends GPanel{
 
         JLabel ccis = new JLabel("Regis University Department of Computer and Cyber Sciences");
         ccis.setFont(new Font("Dialog", Font.PLAIN, 20));
-        ccis.setForeground(new Color(0, 43, 73));
+        ccis.setForeground(REGIS_BLUE);
 
         panel.addc(ccis, 0, 0, 1, 1, 1.0, 1.0,
                 GridBagConstraints.NORTHWEST, GridBagConstraints.HORIZONTAL,
@@ -230,14 +234,14 @@ public class ResetPasswordPanel extends GPanel{
 
     private GPanel createOverview() {
         GPanel panel = new GPanel();
-        panel.setBackground(new Color(241,196,0));
+        panel.setBackground(REGIS_YELLOW);
 
         panel.setSize(300, 400);
         panel.setPreferredSize(new Dimension(300, 400));
 
         JLabel logo = new JLabel("ShaTu");
         logo.setFont(new Font("Dialog", Font.PLAIN, 20));
-        logo.setForeground(new Color(0, 43, 73));
+        logo.setForeground(REGIS_BLUE);
 
         panel.addc(logo, 0, 0, 1, 1, 0.0, 0.0,
                 GridBagConstraints.NORTHWEST, GridBagConstraints.NONE,
@@ -253,7 +257,7 @@ public class ResetPasswordPanel extends GPanel{
         descr.setEditable(false);
         descr.setLineWrap(true);
         descr.setWrapStyleWord(true);
-        descr.setBackground(new Color(241,196,0));
+        descr.setBackground(REGIS_YELLOW);
         descr.setFont(new Font("Dialog", Font.PLAIN, 12));
 	descr.append("ShaTu provides individualized tutoring practice focused ");
 	descr.append("on understanding the SHA-256 digest algorithm and the");
@@ -283,7 +287,7 @@ public class ResetPasswordPanel extends GPanel{
 
     private GPanel createReset() {
         GPanel panel = new GPanel();
-        panel.setBackground(new Color(241,196,0));
+        panel.setBackground(REGIS_YELLOW);
 
         panel.setBorder(BorderFactory.createEmptyBorder(10, 10, 5, 5));
 
@@ -409,7 +413,7 @@ public class ResetPasswordPanel extends GPanel{
                 break;
             case 2:
                 strength.setText("(Strength: Moderate)");
-                strength.setForeground(new Color(255,255,0));
+                strength.setForeground(Color.YELLOW);
                 break;
             default:
                 strength.setText("(Strength: Good)");

--- a/src/main/java/edu/regis/shatu/view/RotateView.java
+++ b/src/main/java/edu/regis/shatu/view/RotateView.java
@@ -30,6 +30,7 @@ import edu.regis.shatu.model.aol.PendingTask;
 import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.aol.RotateStep;
 import edu.regis.shatu.model.aol.StepSubType;
+import edu.regis.shatu.model.aol.TutoringMode;
 import edu.regis.shatu.model.steps.Step;
 
 /**
@@ -292,6 +293,57 @@ public class RotateView extends UserRequestView implements KeyListener {
         
  
     }
+    
+    /**
+     * Configure UI components based on the current tutoring mode
+     * Disables fields not available for SEE_ONE mode for passive viewing.
+     * 
+     */
+    
+    @Override
+    protected void configureModeSpecificUI() {
+        super.configureModeSpecificUI();//call parent to handle buttons
+        
+        if(model == null) {
+            return;
+        }
+        
+        TutoringMode mode = model.getTutoringMode();
+        
+        if (mode == TutoringMode.SEE_ONE) {
+            //Legnth Buttons
+            shortProblem.setEnabled(false);
+            longProblem.setEnabled(false);
+            
+            //Rotation type buttons
+            rightRotate.setEnabled(false);
+            leftRotate.setEnabled(false);
+            
+            //rotation amount buttons
+            rotate7Bits.setEnabled(false);
+            rotate16Bits.setEnabled(false);
+            
+            //Field answer
+            answerField.setEnabled(false);
+        }
+        // DO_ONE & TEACH_ONE
+        else {
+            //Legnth Buttons
+            shortProblem.setEnabled(true);
+            longProblem.setEnabled(true);
+            
+            //Rotation type buttons
+            rightRotate.setEnabled(true);
+            leftRotate.setEnabled(true);
+            
+            //rotation amount buttons
+            rotate7Bits.setEnabled(true);
+            rotate16Bits.setEnabled(true);
+            
+            //Field answer
+            answerField.setEnabled(true);
+        }
+    } 
 
 
     @Override

--- a/src/main/java/edu/regis/shatu/view/ShaOneView.java
+++ b/src/main/java/edu/regis/shatu/view/ShaOneView.java
@@ -22,6 +22,7 @@ import edu.regis.shatu.model.aol.NewExampleRequest;
 import edu.regis.shatu.model.aol.PendingTask;
 import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.aol.StepSubType;
+import edu.regis.shatu.model.aol.TutoringMode;
 
 import edu.regis.shatu.model.steps.ShaOneStep;
 import edu.regis.shatu.model.steps.Step;
@@ -414,6 +415,39 @@ public class ShaOneView extends UserRequestView implements KeyListener { //imple
             }
         }
     }
+    
+    /**
+     * Configure UI components based on the current tutoring mode
+     * Disables fields not available for SEE_ONE mode for passive viewing.
+     * 
+     */
+    
+    @Override
+    protected void configureModeSpecificUI() {
+        super.configureModeSpecificUI();//call parent to handle buttons
+        
+        if(model == null) {
+            return;
+        }
+        
+        TutoringMode mode = model.getTutoringMode();
+        
+        if (mode == TutoringMode.SEE_ONE) {
+            fourRadioButton.setEnabled(false);
+            eightRadioButton.setEnabled(false);
+            sixteenRadioButton.setEnabled(false);
+            thirtytwoRadioButton.setEnabled(false);
+            responseTextArea.setEnabled(false);
+        }
+        // DO_ONE & TEACH_ONE
+        else {
+            fourRadioButton.setEnabled(true);
+            eightRadioButton.setEnabled(true);
+            sixteenRadioButton.setEnabled(true);
+            thirtytwoRadioButton.setEnabled(true);
+            responseTextArea.setEnabled(true);
+        }
+    } 
 
 
     /**

--- a/src/main/java/edu/regis/shatu/view/ShaZeroView.java
+++ b/src/main/java/edu/regis/shatu/view/ShaZeroView.java
@@ -33,6 +33,7 @@ import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.aol.StepSubType;
 import edu.regis.shatu.model.steps.ShaZeroStep;
 import edu.regis.shatu.model.steps.Step;
+import edu.regis.shatu.model.aol.TutoringMode;
 
 
 /**
@@ -499,6 +500,38 @@ public class ShaZeroView extends UserRequestView implements KeyListener {
     }
 
 
+    /**
+     * Configure UI components based on the current tutoring mode
+     * Disables fields not available for SEE_ONE mode for passive viewing.
+     * 
+     */
+    
+    @Override
+    protected void configureModeSpecificUI() {
+        super.configureModeSpecificUI();//call parent to handle buttons
+        
+        if(model == null) {
+            return;
+        }
+        
+        TutoringMode mode = model.getTutoringMode();
+        
+        if (mode == TutoringMode.SEE_ONE) {
+            fourRadioButton.setEnabled(false);
+            eightRadioButton.setEnabled(false);
+            sixteenRadioButton.setEnabled(false);
+            thirtytwoRadioButton.setEnabled(false);
+            responseTextArea.setEnabled(false);
+        }
+        // DO_ONE & TEACH_ONE
+        else {
+            fourRadioButton.setEnabled(true);
+            eightRadioButton.setEnabled(true);
+            sixteenRadioButton.setEnabled(true);
+            thirtytwoRadioButton.setEnabled(true);
+            responseTextArea.setEnabled(true);
+        }
+    } 
     /**
      * Updates the size of the problem to display.
      *

--- a/src/main/java/edu/regis/shatu/view/ShiftRightView.java
+++ b/src/main/java/edu/regis/shatu/view/ShiftRightView.java
@@ -33,8 +33,10 @@ import edu.regis.shatu.model.StepCompletion;
 import edu.regis.shatu.model.aol.NewExampleRequest;
 import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.aol.StepSubType;
+import edu.regis.shatu.model.aol.TutoringMode;
 import edu.regis.shatu.model.steps.BitShiftStep;
 import edu.regis.shatu.model.steps.Step;
+
 
 /**
  * ShiftRightView class represents the GUI view for performing the right shift
@@ -318,6 +320,39 @@ public class ShiftRightView extends UserRequestView implements KeyListener {
             //            + view.getCurrentViewType());
         //}
     }
+    
+    /**
+     * Configure UI components based on the current tutoring mode
+     * Disables fields not available for SEE_ONE mode for passive viewing.
+     * 
+     */
+    
+    @Override
+    protected void configureModeSpecificUI() {
+        super.configureModeSpecificUI();//call parent to handle buttons
+        
+        if(model == null) {
+            return;
+        }
+        
+        TutoringMode mode = model.getTutoringMode();
+        
+        if (mode == TutoringMode.SEE_ONE) {
+            fourRadioButton.setEnabled(false);
+            eightRadioButton.setEnabled(false);
+            sixteenRadioButton.setEnabled(false);
+            thirtytwoRadioButton.setEnabled(false);
+            responseTextArea.setEnabled(false);
+        }
+        // DO_ONE & TEACH_ONE
+        else {
+            fourRadioButton.setEnabled(true);
+            eightRadioButton.setEnabled(true);
+            sixteenRadioButton.setEnabled(true);
+            thirtytwoRadioButton.setEnabled(true);
+            responseTextArea.setEnabled(true);
+        }
+    } 
 
 
     protected void updatePracticeView() {

--- a/src/main/java/edu/regis/shatu/view/SplashPanel.java
+++ b/src/main/java/edu/regis/shatu/view/SplashPanel.java
@@ -53,6 +53,10 @@ public class SplashPanel extends GPanel {
     private static final Color PRIMARY_COLOR = new Color(102, 153, 204); // pastel blue
     private static final Color ACCENT_COLOR = new Color(255, 223, 128);  // pastel yellow
     
+    //Background Colors
+    private static final Color REGIS_BLUE = new Color(0, 43, 73);
+    private static final Color REGIS_YELLOW = new Color(241, 196, 0);
+    
      /**
      * The user model displayed in this view.
      */
@@ -261,7 +265,7 @@ public class SplashPanel extends GPanel {
 
 	JLabel ccis = new JLabel("Regis University Department of Computer and Cyber Sciences Product");
 	ccis.setFont(new Font("Dialog", Font.PLAIN, 20));
-	ccis.setForeground(new Color(0, 43, 73));
+	ccis.setForeground(REGIS_BLUE);
 	
 	panel.addc(ccis , 0,0, 1,1, 1.0,1.0,
 	     GridBagConstraints.NORTHWEST,  GridBagConstraints.HORIZONTAL,
@@ -283,7 +287,7 @@ public class SplashPanel extends GPanel {
     
      private GPanel createLogin() {
 	GPanel panel = new GPanel();
-	panel.setBackground(new Color(241,196,0));
+	panel.setBackground(REGIS_YELLOW);
         panel.setBorder(BorderFactory.createEmptyBorder(10, 10, 5, 5));
 
         JLabel label = new JLabel("Sign in");
@@ -321,14 +325,14 @@ public class SplashPanel extends GPanel {
 
     private GPanel createOverview() {
 	GPanel panel = new GPanel();
-	panel.setBackground(new Color(241,196,0));
+	panel.setBackground(REGIS_YELLOW);
 
 	panel.setSize(300, 400);
 	panel.setPreferredSize(new Dimension(300,400));
 
 	JLabel logo = new JLabel("ShaTu: SHA-256 Tutor");
 	logo.setFont(new Font("Dialog", Font.PLAIN, 20));
-	logo.setForeground(new Color(0, 43, 73));
+	logo.setForeground(REGIS_BLUE);
 
 	panel.addc(logo, 0,0, 1,1, 0.0,0.0,
 		   GridBagConstraints.NORTHWEST,  GridBagConstraints.NONE,
@@ -351,7 +355,7 @@ public class SplashPanel extends GPanel {
         descr.append("based.\n\n");
         descr.append("Please sign in or use 'New User' to create a student account.");
         descr.append("\n\n");
-        descr.setBackground(new Color(241,196,0));
+        descr.setBackground(REGIS_YELLOW);
         
 	panel.addc(descr, 0,2, 1,1, 1.0,1.0,
 		   GridBagConstraints.NORTHWEST,  GridBagConstraints.BOTH,

--- a/src/main/java/edu/regis/shatu/view/StepSelectorView.java
+++ b/src/main/java/edu/regis/shatu/view/StepSelectorView.java
@@ -40,13 +40,17 @@ public class StepSelectorView extends GPanel {
      */
     private Map<String, String> stepAssessmentLevels = new HashMap<>();
     
+    //Background Colors
+    private static final Color REGIS_BLUE = new Color(0, 43, 73);
+    private static final Color REGIS_YELLOW = new Color(241, 196, 0);
+    
     /**
      * Initialize this view including creating and laying out its child components.
      */
     public StepSelectorView() {
         GuiController.instance().setStepSelectorView(this);
  
-        setBackground(new Color(241,196,0));
+        setBackground(REGIS_YELLOW);
         setBorder(BorderFactory.createLineBorder(Color.WHITE));
         stepAssessmentLevels = fetchStepAssessments();
         initializeComponents();
@@ -105,7 +109,7 @@ public class StepSelectorView extends GPanel {
     private GPanel createPreprocessingPanel() {
         GPanel panel = new GPanel();
         
-        panel.setBackground(new Color(0, 43, 73)); // Blue
+        panel.setBackground(REGIS_BLUE);
         panel.setBorder(BorderFactory.createLineBorder(Color.BLACK));
         
         JLabel label = new JLabel("Message Preprocessing");
@@ -136,7 +140,7 @@ public class StepSelectorView extends GPanel {
     private GPanel createHashCompPanel() {
         GPanel panel = new GPanel();
         
-        panel.setBackground(new Color(0, 43, 73)); // Dark Regis Blue
+        panel.setBackground(REGIS_BLUE); 
         panel.setBorder(BorderFactory.createLineBorder(Color.BLACK));
         
         JLabel label = new JLabel("Hash Computation");

--- a/src/main/java/edu/regis/shatu/view/TutoringSessionView.java
+++ b/src/main/java/edu/regis/shatu/view/TutoringSessionView.java
@@ -24,6 +24,7 @@ import edu.regis.shatu.model.TutoringSession;
 import edu.regis.shatu.model.aol.PendingStep;
 import edu.regis.shatu.model.aol.PendingTask;
 import edu.regis.shatu.model.aol.StepSubType;
+import edu.regis.shatu.model.aol.TutoringMode;
 
 /**
  * Displays a tutoring session.
@@ -109,6 +110,8 @@ public class TutoringSessionView extends GPanel {
 
             stepView.setModel(model);
         }
+        
+        configureModeSpecificUI();
     }
     
     /**
@@ -145,6 +148,45 @@ public class TutoringSessionView extends GPanel {
         //ToDo: Are there any special components that depend on the Tutoring Mode?
     }
 
+    /**
+     * New Method to
+     */
+    private void configureModeSpecificUI() {
+        
+        //Check if no model, nothing to configure
+        if (model == null) {
+            return;
+        }
+        
+        
+        TutoringMode mode = model.getTutoringMode();
+        
+        switch (mode) {
+            case SEE_ONE:
+                for (StepSelection step : StepSelection.values()) {
+                    HighlightLabel label = step.getLabel();
+                    label.setEnabled(false);
+                }
+                break;
+            
+            //Separated just in case logic later requires separate behavior    
+            case DO_ONE: {
+                for (StepSelection step : StepSelection.values()) {
+                    HighlightLabel label = step.getLabel();
+                    label.setEnabled(true);
+                }
+                break;
+            }
+            case TEACH_ONE:
+                for (StepSelection step : StepSelection.values()) {
+                    HighlightLabel label = step.getLabel();
+                    label.setEnabled(true);
+                }
+                break;
+        }
+    }
+    
+    
     /**
      * Layout the components
      */

--- a/src/main/java/edu/regis/shatu/view/UserRequestView.java
+++ b/src/main/java/edu/regis/shatu/view/UserRequestView.java
@@ -24,6 +24,7 @@ import edu.regis.shatu.model.aol.PendingTask;
 import edu.regis.shatu.view.act.HintAction;
 import edu.regis.shatu.view.act.NewExampleAction;
 import edu.regis.shatu.view.act.StepCompletionAction;
+import edu.regis.shatu.model.aol.TutoringMode;
 import java.awt.GridBagConstraints;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -106,8 +107,38 @@ public abstract class UserRequestView extends GPanel {
     public void setModel(TutoringSession model) {
         random = new Random();
         this.model = model;
+        configureModeSpecificUI();
         updateView();
     }
+    
+    /**
+     * Configure UI components based on the current tutoring mode. 
+     * Disables fields not available for SEE_ONE mode for passive viewing.
+     */
+    protected void configureModeSpecificUI(){
+        if (model == null) {
+            return;
+        }
+        
+        TutoringMode mode = model.getTutoringMode();
+        
+        if (mode == TutoringMode.SEE_ONE) {
+            checkButton.setEnabled(false);
+            hintButton.setEnabled(false);
+            newExampleButton.setEnabled(false);
+        } else if (mode == TutoringMode.DO_ONE) {
+            checkButton.setEnabled(true);
+            hintButton.setEnabled(true);
+            newExampleButton.setEnabled(true);
+        } else if (mode == TutoringMode.TEACH_ONE) {
+            checkButton.setEnabled(true);
+            hintButton.setEnabled(true);
+            newExampleButton.setEnabled(true);
+        }
+        
+    }
+    
+    
     
     /**
      * Assign the given task as the current task in our tutoring session model

--- a/src/main/java/edu/regis/shatu/view/act/CreateAcctAction.java
+++ b/src/main/java/edu/regis/shatu/view/act/CreateAcctAction.java
@@ -21,11 +21,13 @@ import javax.swing.JOptionPane;
 import com.google.gson.Gson;
 
 import edu.regis.shatu.model.Account;
+import edu.regis.shatu.model.TutoringSession;
 import edu.regis.shatu.svc.ClientRequest;
 import edu.regis.shatu.svc.ServerRequestType;
 import edu.regis.shatu.svc.SvcFacade;
 import edu.regis.shatu.svc.TutorReply;
 import edu.regis.shatu.view.MainFrame;
+
 
 /**
  * An MVC controller handling a user GUI gesture requesting the creation of a
@@ -97,11 +99,26 @@ public class CreateAcctAction extends ShaTuGuiAction {
         switch (reply.getStatus()) {
             case "Created":
                 frame.clearNewAccountPanel();
-                msg = "Student user account successfully created\n\n" +
-                        "Press okay and we'll return you to the sign-in screen\n\n" +
-                        "Then, please sign-in to the tutor using this account.";
-                JOptionPane.showMessageDialog(frame, msg);
-                frame.displayView(MainFrame.ViewName.SPLASH);
+                
+                //AutoLogin Transition to tutoring sesh
+                try {
+                    TutoringSession session = gson.fromJson(reply.getData(), TutoringSession.class);
+                    frame.setModel(session);
+                    
+                    msg = "Welcome to ShaTu!\n\n" +
+                          "Your account has been created successfully.\n" +
+                          "Let's begin with 'See One' mode where you'll observe\n" +
+                          "how the SHA-256 algorithm works.";
+                    JOptionPane.showMessageDialog(frame, msg, "Welcome", 
+                                                  JOptionPane.INFORMATION_MESSAGE);
+                } catch (Exception e) {
+                    // If auto-login fails, fall back to manual sign-in
+                    LOGGER.severe("Failed to auto-login after account creation: " + e.getMessage());
+                    msg = "Account created successfully!\n\n" +
+                          "Please sign in to begin.";
+                    JOptionPane.showMessageDialog(frame, msg);
+                    frame.displayView(MainFrame.ViewName.SPLASH);
+                }
                 break;
             case "IllegalUserId":
                 msg = "User id already exists: " + account.getUserId();


### PR DESCRIPTION
Summary
Implements SEE_ONE mode UI control disabling and automatic login after account creation.

Changes Made
- Disabled input fields in 7 view files when in SEE_ONE mode
- Auto-login new users after account creation
- Initialize sessions in SEE_ONE mode with first task
- Updated 4 additional panel files for consistency

Files Modified
- `ShaTuTutor.java` - Session initialization and TutoringMode setup
- `CreateAcctAction.java` - Auto-login implementation
- 7 View files - `configureModeSpecificUI()` implementation
- 4 Panel files - UI consistency updates

Testing
- Verified input fields disabled in SEE_ONE mode
- Tested new account creation flow
- Confirmed auto-login works correctly
- Validated session starts with correct task

Related Ticket
SHAT-327