### PR TITLE
SHAT-UI Add centralized ColorScheme class for consistent color styling

### DIFF
--- a/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
+++ b/src/main/java/edu/regis/shatu/view/CompressionCanvasView.java
@@ -30,6 +30,7 @@ import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.steps.CompressRoundStep;
 import edu.regis.shatu.model.steps.Step;
 import edu.regis.shatu.svc.SHA_256;
+import edu.regis.shatu.view.style.ColorScheme;
 
 /**
  * Displays a single round of the SHA-256 compression algorithm.
@@ -368,8 +369,7 @@ public class CompressionCanvasView extends UserRequestView implements ActionList
     }
 
     private void layoutComponents() {
-        Color white = Color.WHITE;
-        setBackground(white);
+        setBackground(ColorScheme.WHITE);
         Point p;
         int x, y, newMessageX, roundX, roundY;
 

--- a/src/main/java/edu/regis/shatu/view/DashboardPanel.java
+++ b/src/main/java/edu/regis/shatu/view/DashboardPanel.java
@@ -42,6 +42,7 @@ import edu.regis.shatu.model.aol.Assessment;
 import edu.regis.shatu.model.aol.StudentModel;
 import edu.regis.shatu.svc.ServiceFactory;
 import edu.regis.shatu.svc.StudentModelSvc;
+import edu.regis.shatu.view.style.ColorScheme;
 
 /**
  * The dashboard screen to be displayed upon user sign in. Enables user to
@@ -83,8 +84,8 @@ public class DashboardPanel extends JPanel {
     private static final String URL = "jdbc:mysql://localhost:3306/shatudb?serverTimezone=UTC";
 
     //Background Colors
-    private static final Color REGIS_BLUE = new Color(0, 43, 73);
-    private static final Color REGIS_YELLOW = new Color(241, 196, 0);
+//    private static final Color REGIS_BLUE = new Color(0, 43, 73);
+//    private static final Color REGIS_YELLOW = new Color(241, 196, 0);
     
     
     /**
@@ -133,10 +134,10 @@ public class DashboardPanel extends JPanel {
         // Header components
         settingsButton = new JButton("Settings");
         welcomeLabel = new JLabel();
-        welcomeLabel.setBackground(REGIS_BLUE);
+        welcomeLabel.setBackground(ColorScheme.REGIS_BLUE);
         welcomeLabel.setOpaque(true);
         welcomeLabel.setFont(new Font("Segoe UI", Font.PLAIN, 18));
-        welcomeLabel.setForeground(REGIS_YELLOW);
+        welcomeLabel.setForeground(ColorScheme.REGIS_YELLOW);
         welcomeLabel.setHorizontalAlignment(SwingConstants.CENTER);
 
         // Study mode buttons
@@ -148,7 +149,7 @@ public class DashboardPanel extends JPanel {
         settingsButton.setVerticalAlignment(SwingConstants.TOP);  
         
         seeOneButton.addActionListener(evt -> {
-            MainFrame.instance().displayView(MainFrame.ViewName.SPLASH);
+            MainFrame.instance().displayView(MainFrame.ViewName.TUTOR);
         });
         
         doOneButton.addActionListener(evt -> {
@@ -287,7 +288,7 @@ public class DashboardPanel extends JPanel {
 
         // Content panel
         JPanel contentPanel = new JPanel(new GridBagLayout());
-        contentPanel.setBackground(REGIS_BLUE);
+        contentPanel.setBackground(ColorScheme.REGIS_BLUE);
         GridBagConstraints gbc = new GridBagConstraints();
         gbc.fill = GridBagConstraints.BOTH;
         gbc.insets = new Insets(5, 5, 5, 5);
@@ -461,7 +462,7 @@ public class DashboardPanel extends JPanel {
         }
 
         JPanel panel = new JPanel(new GridBagLayout());
-        panel.setBackground(REGIS_YELLOW); // Yellow background
+        panel.setBackground(ColorScheme.REGIS_YELLOW); // Yellow background
         panel.setBorder(new CompoundBorder(new LineBorder(Color.BLACK), new EmptyBorder(5, 5, 5, 5)));
 
         GridBagConstraints gbc = new GridBagConstraints();
@@ -491,7 +492,7 @@ public class DashboardPanel extends JPanel {
         overallBar.setStringPainted(true);
         overallBar.setPreferredSize(new Dimension(70, 35));
         overallBar.setFont(new Font("Segoe UI", Font.BOLD, 16));
-        overallBar.setForeground(REGIS_BLUE);
+        overallBar.setForeground(ColorScheme.REGIS_BLUE);
         overallBar.setBackground(Color.WHITE);
         overallBar.setString(overall + "%");
         gbc.gridy = 1;
@@ -511,7 +512,7 @@ public class DashboardPanel extends JPanel {
         gbc.gridwidth = 2;
         gbc.weighty = 1.0;
         JPanel filler = new JPanel();
-        filler.setBackground(REGIS_YELLOW);
+        filler.setBackground(ColorScheme.REGIS_YELLOW);
         panel.add(filler, gbc);
 
         //Save Reference to Overall Bar
@@ -591,7 +592,7 @@ public class DashboardPanel extends JPanel {
                 bar.setStringPainted(true);
                 bar.setPreferredSize(new Dimension(35, 25));
                 bar.setFont(new Font("Segoe UI", Font.BOLD, 16));
-                bar.setForeground(REGIS_BLUE);
+                bar.setForeground(ColorScheme.REGIS_BLUE);
                 bar.setBackground(Color.WHITE);
                 bar.setString(progress + "%");
                 panel.add(bar, gbc);

--- a/src/main/java/edu/regis/shatu/view/NewAccountPanel.java
+++ b/src/main/java/edu/regis/shatu/view/NewAccountPanel.java
@@ -41,6 +41,7 @@ import edu.regis.shatu.model.Account;
 import edu.regis.shatu.view.act.BackToLogin;
 import edu.regis.shatu.view.act.CreateAcctAction;
 import edu.regis.shatu.view.act.SignInAction;
+import edu.regis.shatu.view.style.ColorScheme;
 
 /**
  * New user screen that also allows the student to create an IRBt account
@@ -209,7 +210,7 @@ public class NewAccountPanel extends GPanel {
     }
 
     private void layoutPanel() {
-        setBackground(new Color(0, 43, 73));
+        setBackground(ColorScheme.REGIS_BLUE);
 
         setPreferredSize(new Dimension(300, 400));
 
@@ -227,7 +228,7 @@ public class NewAccountPanel extends GPanel {
 
         JLabel copyright = new JLabel("(C) 2019-2025 Johanna and Richard Blumenthal. All Rights Reserved");
         copyright.setFont(new Font("Dialog", Font.PLAIN, 10));
-        copyright.setForeground(new Color(241,196,0));
+        copyright.setForeground(ColorScheme.REGIS_YELLOW);
         addc(copyright, 0, 2, 2, 1, 1.0, 1.0,
                 GridBagConstraints.NORTH, GridBagConstraints.CENTER,
                 5, 5, 5, 5);
@@ -237,11 +238,11 @@ public class NewAccountPanel extends GPanel {
 
     private GPanel createHeader() {
         GPanel panel = new GPanel();
-        panel.setBackground(new Color(241,196,0));
+        panel.setBackground(ColorScheme.REGIS_YELLOW);
 
         JLabel ccis = new JLabel("Regis University Department of Computer and Cyber Sciences");
         ccis.setFont(new Font("Dialog", Font.PLAIN, 20));
-        ccis.setForeground(new Color(0, 43, 73));
+        ccis.setForeground(ColorScheme.REGIS_BLUE);
 
         panel.addc(ccis, 0, 0, 1, 1, 1.0, 1.0,
                 GridBagConstraints.NORTHWEST, GridBagConstraints.HORIZONTAL,
@@ -252,14 +253,14 @@ public class NewAccountPanel extends GPanel {
 
     private GPanel createOverview() {
         GPanel panel = new GPanel();
-        panel.setBackground(new Color(241,196,0));
+        panel.setBackground(ColorScheme.REGIS_YELLOW);
 
         panel.setSize(300, 400);
         panel.setPreferredSize(new Dimension(300, 400));
 
         JLabel logo = new JLabel("ShaTu");
         logo.setFont(new Font("Dialog", Font.PLAIN, 20));
-        logo.setForeground(new Color(0, 43, 73));
+        logo.setForeground(ColorScheme.REGIS_BLUE);
 
         panel.addc(logo, 0, 0, 1, 1, 0.0, 0.0,
                 GridBagConstraints.NORTHWEST, GridBagConstraints.NONE,
@@ -275,7 +276,7 @@ public class NewAccountPanel extends GPanel {
         descr.setEditable(false);
         descr.setLineWrap(true);
         descr.setWrapStyleWord(true);
-        descr.setBackground(new Color(241,196,0));
+        descr.setBackground(ColorScheme.REGIS_YELLOW);
         descr.setFont(new Font("Dialog", Font.PLAIN, 12));
 	descr.append("ShaTu provides individualized tutoring practice focused ");
 	descr.append("on understanding the SHA-256 digest algorithm and the");
@@ -305,7 +306,7 @@ public class NewAccountPanel extends GPanel {
 
     private GPanel createLogin() {
         GPanel panel = new GPanel();
-        panel.setBackground(new Color(241,196,0));
+        panel.setBackground(ColorScheme.REGIS_YELLOW);
 
         panel.setBorder(BorderFactory.createEmptyBorder(10, 10, 5, 5));
 

--- a/src/main/java/edu/regis/shatu/view/SplashPanel.java
+++ b/src/main/java/edu/regis/shatu/view/SplashPanel.java
@@ -35,6 +35,7 @@ import edu.regis.shatu.svc.SHA_256;
 import edu.regis.shatu.view.act.ForgotPasswordAction;
 import edu.regis.shatu.view.act.NewUserAction;
 import edu.regis.shatu.view.act.SignInAction;
+import edu.regis.shatu.view.style.ColorScheme;
 
 /**
  * A splash panel introducing the ShaTut tutor, which also allows the user to 
@@ -49,9 +50,6 @@ public class SplashPanel extends GPanel {
      * Events of interest occurring in this class are logged to this logger.
      */
     private static final Logger LOGGER = Logger.getLogger(SplashPanel.class.getName());
-    
-    private static final Color PRIMARY_COLOR = new Color(102, 153, 204); // pastel blue
-    private static final Color ACCENT_COLOR = new Color(255, 223, 128);  // pastel yellow
     
      /**
      * The user model displayed in this view.
@@ -231,7 +229,7 @@ public class SplashPanel extends GPanel {
      * Layout the child components used in this view.
      */
     private void layoutComponents() {
-        setBackground(PRIMARY_COLOR);
+        setBackground(ColorScheme.REGIS_BLUE_PASTEL);
 	addc(createHeader(), 0,0, 2,1, 1.0,0.0,
 	     GridBagConstraints.NORTHWEST,  GridBagConstraints.HORIZONTAL,
 	     5,5,5,5);	
@@ -246,7 +244,7 @@ public class SplashPanel extends GPanel {
             5,5,5,5);
         
         JLabel copyright = new JLabel("(C) 2019-2025 Johanna and Richard Blumenthal. All Rights Reserved");
-        copyright.setForeground(ACCENT_COLOR);
+        copyright.setForeground(ColorScheme.REGIS_YELLOW_PASTEL);
         copyright.setFont(new Font("Dialog", Font.PLAIN, 10));
         addc(copyright, 0,3, 2,1, 1.0,1.0,
 		GridBagConstraints.NORTH,  GridBagConstraints.CENTER,

--- a/src/main/java/edu/regis/shatu/view/style/ColorScheme.java
+++ b/src/main/java/edu/regis/shatu/view/style/ColorScheme.java
@@ -1,0 +1,28 @@
+/*
+ *  SHATU: SHA-256 Tutor
+ * 
+ *   (C) Johanna & Richard Blumenthal, All rights reserved
+ * 
+ *   Unauthorized use, duplication or distribution without the authors'
+ *   permission is strictly prohibited.
+ * 
+ *   Unless required by applicable law or agreed to in writing, this
+ *   software is distributed on an "AS IS" basis without warranties
+ *   or conditions of any kind, either expressed or implied.
+ */
+package edu.regis.shatu.view.style;
+
+import java.awt.Color;
+
+/**
+ * Contains the colors used throughout the application.
+ *
+ * @author Henry Ordonez
+ */
+public class ColorScheme {
+    public static final Color REGIS_BLUE = new Color(0, 43, 73);
+    public static final Color REGIS_YELLOW = new Color(241, 196, 0);
+    public static final Color REGIS_BLUE_PASTEL = new Color(102, 153, 204);
+    public static final Color REGIS_YELLOW_PASTEL = new Color(255, 223, 128);
+    public static final Color WHITE = Color.WHITE;
+}


### PR DESCRIPTION
### Summary
Introduces a centralized 'ColorScheme' class to manage GUI colors more consistently and adds functionality to the 'See One' button in the Dashboardpanel class.

### Changes
- Added ColorScheme.java under newly created edu.regis.shatu.view.style
- Applied color constants to:
    - Dashboardpanel.java
    - SplashPanel.java
    - NewAccountPanel.java
    - CompressionCanvasView.java
- Added functionality to 'See One' button

### Reasoning
Having a centralized location for colors makes the application more visually cohesive and scalable.

### Notes
- Colors are the same as before
- Update to Dashboardpanel.java 'See One' button now takes the user to the Tutor view when clicked