### PR TITLE
Fixed compiler issues, and others, with DB sign in and out logging

### DIFF
--- a/nbactions.xml
+++ b/nbactions.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<actions>
+        <action>
+            <actionName>run</actionName>
+            <packagings>
+                <packaging>jar</packaging>
+            </packagings>
+            <goals>
+                <goal>process-classes</goal>
+                <goal>org.codehaus.mojo:exec-maven-plugin:3.1.0:exec</goal>
+            </goals>
+            <properties>
+                <exec.vmArgs></exec.vmArgs>
+                <exec.args>${exec.vmArgs} -classpath %classpath ${exec.mainClass} ${exec.appArgs}</exec.args>
+                <exec.appArgs></exec.appArgs>
+                <exec.mainClass>${packageClassName}</exec.mainClass>
+                <exec.executable>java</exec.executable>
+            </properties>
+        </action>
+        <action>
+            <actionName>debug</actionName>
+            <packagings>
+                <packaging>jar</packaging>
+            </packagings>
+            <goals>
+                <goal>process-classes</goal>
+                <goal>org.codehaus.mojo:exec-maven-plugin:3.1.0:exec</goal>
+            </goals>
+            <properties>
+                <exec.vmArgs>-agentlib:jdwp=transport=dt_socket,server=n,address=${jpda.address}</exec.vmArgs>
+                <exec.args>${exec.vmArgs} -classpath %classpath ${exec.mainClass} ${exec.appArgs}</exec.args>
+                <exec.appArgs></exec.appArgs>
+                <exec.mainClass>${packageClassName}</exec.mainClass>
+                <exec.executable>java</exec.executable>
+                <jpda.listen>true</jpda.listen>
+            </properties>
+        </action>
+        <action>
+            <actionName>profile</actionName>
+            <packagings>
+                <packaging>jar</packaging>
+            </packagings>
+            <goals>
+                <goal>process-classes</goal>
+                <goal>org.codehaus.mojo:exec-maven-plugin:3.1.0:exec</goal>
+            </goals>
+            <properties>
+                <exec.vmArgs></exec.vmArgs>
+                <exec.args>${exec.vmArgs} -classpath %classpath ${exec.mainClass} ${exec.appArgs}</exec.args>
+                <exec.mainClass>${packageClassName}</exec.mainClass>
+                <exec.executable>java</exec.executable>
+                <exec.appArgs></exec.appArgs>
+            </properties>
+        </action>
+    </actions>

--- a/src/main/java/edu/regis/shatu/dao/StudentModelDAO.java
+++ b/src/main/java/edu/regis/shatu/dao/StudentModelDAO.java
@@ -31,6 +31,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -41,10 +42,7 @@ public class StudentModelDAO extends MySqlDAO implements StudentModelSvc {
     }
 
     /**
-     * Creates a new student model and its associated assessment records.
-     *
-     * @param student the student for whom the model is created.
-     * @throws NonRecoverableException if an error occurs during creation.
+     * {@inheritDoc}
      */
     @Override
     public void create(Student student) throws NonRecoverableException {
@@ -88,12 +86,7 @@ public class StudentModelDAO extends MySqlDAO implements StudentModelSvc {
     }
 
     /**
-     * Retrieves the student model along with its assessment records.
-     *
-     * @param userId the user id.
-     * @return the student model.
-     * @throws ObjNotFoundException if the student model is not found.
-     * @throws NonRecoverableException if an error occurs during retrieval.
+     * {@inheritDoc}
      */
     @Override
     public StudentModel retrieve(String userId) throws ObjNotFoundException, NonRecoverableException {
@@ -123,12 +116,7 @@ public class StudentModelDAO extends MySqlDAO implements StudentModelSvc {
     }
 
     /**
-     * Updates a specific field in an assessment.
-     *
-     * @param model the student model.
-     * @param assessment the assessment to update.
-     * @param field the field to update.
-     * @throws NonRecoverableException if an error occurs during the update.
+     * {@inheritDoc}
      */
     @Override
     public void updateAssessment(StudentModel model, Assessment assessment, StudentModelFieldKind field)
@@ -176,23 +164,7 @@ public class StudentModelDAO extends MySqlDAO implements StudentModelSvc {
     }
 
     /**
-     * Retrieves a list of unfinished lessons for a student in a specific learning
-     * category.
-     * 
-     * The category is inferred from `AssessmentLevel`:
-     * - "Not Started" → Teach Me
-     * - "In Progress" → Practice
-     * - "Completed", "Very Low", "Low", "Medium", "High", "Very High" → Quiz Me
-     *
-     * If a lesson is not yet completed in a **previous category**, it will indicate
-     * that.
-     *
-     * @param userId           The unique identifier of the student.
-     * @param learningCategory The learning category ("Teach Me", "Practice", "Quiz
-     *                         Me").
-     * @return A list of unfinished lesson names, formatted accordingly.
-     * @throws ObjNotFoundException    If the student record is not found.
-     * @throws NonRecoverableException If a database error occurs.
+     * {@inheritDoc}
      */
     @Override
     public List<String> retrieveIncompleteLessons(String userId, String learningCategory)
@@ -292,13 +264,7 @@ public class StudentModelDAO extends MySqlDAO implements StudentModelSvc {
     }
 
     /**
-     * Retrieves the assessment level for a given lesson.
-     *
-     * @param userId the user id.
-     * @param lesson the lesson title.
-     * @return the assessment level.
-     * @throws ObjNotFoundException if the assessment record is not found.
-     * @throws NonRecoverableException if an error occurs during retrieval.
+     * {@inheritDoc}
      */
     @Override
     public AssessmentLevel retrieveAssessmentLevel(String userId, String lesson)
@@ -329,7 +295,10 @@ public class StudentModelDAO extends MySqlDAO implements StudentModelSvc {
         }
     }
 
-     @Override
+   /**
+     * {@inheritDoc}
+     */
+    @Override
     public void updateScaffoldLevel(String userId, ScaffoldLevel level)
             throws ObjNotFoundException, NonRecoverableException {
         final String sql = "UPDATE StudentModel SET ScaffoldLevel = ? WHERE UserId = ?";
@@ -383,28 +352,39 @@ public class StudentModelDAO extends MySqlDAO implements StudentModelSvc {
         return assessments;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean exists(String userId) throws NonRecoverableException {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
-    @Override
-    public StudentModel findModelById(String userId) throws ObjNotFoundException, NonRecoverableException {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void delete(String userId) throws NonRecoverableException {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
-    public void recordLoginEvent(int studentId, LocalDateTime timestamp) {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void recordLoginEvent(String userId, long timestamp) {
         String sql = "UPDATE students SET last_login = ? WHERE id = ?";
+        // ToDo: Write this code
         // execute with JDBC/SQLite/whatever DB is used
-}
-
-    public void recordLogoutEvent(int studentId, LocalDateTime timestamp) {
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void recordLogoutEvent(String userId, long timestamp) {
         String sql = "UPDATE students SET last_logout = ? WHERE id = ?";
+        // ToDo Write this code
         // execute DB update here
-}
+    }
 }

--- a/src/main/java/edu/regis/shatu/model/Student.java
+++ b/src/main/java/edu/regis/shatu/model/Student.java
@@ -31,6 +31,17 @@ public class Student {
      */
     private StudentModel studentModel;
     
+    // ToDo: What are these being used for. If it's for the purpose of 
+    // tutoring assessment, then they should be in the studentModel???
+    // These are time in milliseonces
+    //  Date date = new Date(milliseconds);
+    // SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS z", Locale.US);
+    // Optional: Set the time zone if you need a specific one (e.g., UTC)
+    // sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+    // String formattedDate = sdf.format(date);
+    private long lastLogin;
+    private long lastLogout;
+    
     /**
      * Initialize this student with the given account information.
      * 
@@ -68,18 +79,40 @@ public class Student {
         this.studentModel = studentModel;
     }
 
+    /**
+     * 
+     * @return time in milliseconds (see comments on this field)
+     */
+    public long getLastLogin() { 
+        return lastLogin; 
+    }
+    
+    /**
+     * 
+     * @param lastLogin time in milliseconds (see comments on this field)
+     */
+    public void setLastLogin(long lastLogin) { 
+        this.lastLogin = lastLogin; 
+    }
+
+    /**
+     * 
+     * @return time in milliseconds (see comments on this field)
+     */
+    public long getLastLogout() { 
+        return lastLogout; 
+    }
+    
+    /**
+     * 
+     * @param lastLogout time in milliseconds (see comments on this field)
+     */
+    public void setLastLogout(long lastLogout) { 
+        this.lastLogout = lastLogout; 
+    }
+    
     @Override
     public String toString() {
         return "Student: " + account.getUserId();
     }
-
-    private LocalDateTime lastLogin;
-    private LocalDateTime lastLogout;
-
-    // Getters and setters
-    public LocalDateTime getLastLogin() { return lastLogin; }
-    public void setLastLogin(LocalDateTime lastLogin) { this.lastLogin = lastLogin; }
-
-    public LocalDateTime getLastLogout() { return lastLogout; }
-    public void setLastLogout(LocalDateTime lastLogout) { this.lastLogout = lastLogout; }
 }

--- a/src/main/java/edu/regis/shatu/svc/ShaTuTutor.java
+++ b/src/main/java/edu/regis/shatu/svc/ShaTuTutor.java
@@ -45,6 +45,7 @@ import edu.regis.shatu.model.aol.StudentModel;
 import edu.regis.shatu.model.aol.TutoringMode;
 import edu.regis.shatu.model.steps.Step;
 import edu.regis.shatu.objectives.*;
+import java.util.Date;
 
 /**
  * The ShaTu tutor, which implements the tutoring service.
@@ -796,23 +797,44 @@ public class ShaTuTutor implements TutorSvc {
         return sb.toString();
     }
 
-    private StudentDao studentDao = new StudentDao();
+    /**
+     * Update the database to record the fact the student logged in.
+     * 
+     * @param student the student who logged in.
+     * @throws ObjNotFoundException
+     * @throws NonRecoverableException 
+     */
+    public void notifyLogin(Student student) throws ObjNotFoundException, NonRecoverableException {
+        // ToDo: This needs to be called suring a sign in. 
+        StudentModelSvc stuModelSvc = ServiceFactory.findStudentModelSvc();
+        
+                Date now = new Date();
+        long milliseconds = now.getTime();
+        student.setLastLogin(milliseconds);
 
-    public void notifyLogin(Student student) {
-        LocalDateTime now = LocalDateTime.now();
-        student.setLastLogin(now);
-        studentDao.recordLoginEvent(student.getId(), now);
+        stuModelSvc.recordLoginEvent(student.getAccount().getUserId(), milliseconds);
 
-        // Notify tutor system (log, push message, etc.)
-        LOGGER.info("Student " + student.getUsername() + " logged in at " + now);
+       // LOGGER.log(Level.INFO, "Student {0} logged in at {1}", new Object[]{student.getAccount().getUserId(), milliseconds});
     }
 
-    public void notifyLogout(Student student) {
-        LocalDateTime now = LocalDateTime.now();
-        student.setLastLogout(now);
-        studentDao.recordLogoutEvent(student.getId(), now);
+    /**
+     * Update the database to record the fact the student signed out.
+     * 
+     * @param student the student who logged out.
+     * @throws ObjNotFoundException
+     * @throws NonRecoverableException 
+     */
+    public void notifyLogout(Student student) throws ObjNotFoundException, NonRecoverableException {
+        // ToDo: This needs to be called during a signout.
+        StudentModelSvc stuModelSvc = ServiceFactory.findStudentModelSvc();
+        
+        Date now = new Date();
+        long milliseconds = now.getTime();
+        
+        student.setLastLogout(now.getTime());
+        stuModelSvc.recordLogoutEvent(student.getAccount().getUserId(), milliseconds);
 
-        LOGGER.info("Student " + student.getUsername() + " logged out at " + now);
+       // LOGGER.log(Level.INFO, "Student {0} logged out at {1}", new Object[]{student.getAccount().getUserId(), milliseconds});
     }
 
 

--- a/src/main/java/edu/regis/shatu/svc/StudentModelSvc.java
+++ b/src/main/java/edu/regis/shatu/svc/StudentModelSvc.java
@@ -54,7 +54,7 @@ public interface StudentModelSvc {
     boolean exists(String userId) throws NonRecoverableException;
     
     /**
-     * Return the {@link Student} with the given user id.
+     * Return the {@link StudentModel} with the given user id.
      * 
      * See exists(String) for a faster check as to whether a student exists.
      * 
@@ -65,17 +65,6 @@ public interface StudentModelSvc {
      */
     StudentModel retrieve(String userId) throws ObjNotFoundException, NonRecoverableException;
     
-    /**
-     * Return the {@link StudentModel} for the given user id.
-     * 
-     * @param userId the student's user id (email: user@university.edu)
-     * @return the StudentModel for the Student with the given user id
-     * @throws ObjNotFoundException No student with the given user id exists
-
-     * @throws NonRecoverableException perhaps see getCause().getErrorCode()
-     */
-    StudentModel findModelById(String userId) throws ObjNotFoundException, 
-            NonRecoverableException;
     
     /**
      * Delete the student from the database including the student's account,
@@ -97,8 +86,16 @@ public interface StudentModelSvc {
     void updateAssessment(StudentModel model, Assessment assessment, StudentModelFieldKind field)
             throws NonRecoverableException;
     
-       /**
+    /**
     * Retrieve a list of unfinished lessons for a student in a specific learning mode.
+    * 
+    * The category is inferred from `AssessmentLevel`:
+    * - "Not Started" → Teach Me
+    * - "In Progress" → Practice
+    * - "Completed", "Very Low", "Low", "Medium", "High", "Very High" → Quiz Me
+    *
+    * If a lesson is not yet completed in a **previous category**, it will indicate
+    * that.
     * 
     * @param userId the unique identifier for the student.
     * @param learningCategory the category of learning (e.g., "Teach Me", "Practice", "Quiz Me").
@@ -130,5 +127,27 @@ public interface StudentModelSvc {
      * @throws ObjNotFoundException if no student model is found.
      */
     void updateScaffoldLevel(String userId, ScaffoldLevel level)
+            throws ObjNotFoundException, NonRecoverableException;
+    
+    /**
+     * Record the fact that the given student signed into the tutor.
+     * 
+     * @param userId the user id of the student
+     * @param timestamp time in milliseconds 
+     * @throws ObjNotFoundException
+     * @throws NonRecoverableException 
+     */
+    void recordLoginEvent(String userId, long timestamp)
+            throws ObjNotFoundException, NonRecoverableException;
+    
+    /**
+     * Record the fact that the given student signed out of the tutor.
+     * 
+     * @param userId the user id of the student
+     * @param timestamp time in milliseconds (see comments on this field)
+     * @throws ObjNotFoundException
+     * @throws NonRecoverableException 
+     */
+    void recordLogoutEvent(String userId, long timestamp)
             throws ObjNotFoundException, NonRecoverableException;
 }


### PR DESCRIPTION
There were compiler issues with the handling of recordLoginEvent and recordLogoutEvent in StudentModel service.
These are fixed. Also modified this approach to :
   use userId instead of studentId
   obtain StudentSvc from ServiceFactory  (student svc is none existent)
   Use time in milliseconds long in Account (since Java DateTime doesn't serialize in GSon).

Note, these services remain unimplemented. ToDo:
  Update StudentModelDAO
  Update ShaTuTutor to call the notifyLogin and notifyLogout methods during signin and signout requests.