### PR TITLE
SHAT-330 Assign Problems to Tasks and update DB setup script

### DIFF
--- a/setup_ShaTuDB.sql
+++ b/setup_ShaTuDB.sql
@@ -5,482 +5,487 @@
 -- Unless required by applicable law or agreed to in writing, this software is distributed on an "AS IS" basis without warranties or conditions of any kind, either expressed or implied.
 -- Authors: chand, rickb
 -- Created: Nov 8, 2024
-
+-- Last modified: October 22, 2025 for SHAT-330
 
 -- If the ShaTuDB exists, drop it. In general, you will lose any existing data.
 DROP DATABASE IF EXISTS ShaTuDB;
 
-
--- Create a database in MySql named: DiceTsDB
+-- Create a database in MySql named: ShaTuDB
 CREATE DATABASE ShaTuDB;
 
--- Create user representing the DICE tutor.
+-- Create user representing the ShaTu tutor.
 CREATE USER IF NOT EXISTS 'ShaTuTs'@'localhost' IDENTIFIED BY 'ShaTu2023';
 
 -- Give the ShaTu tutor the following priveledges.
 GRANT SELECT,INSERT,UPDATE,DELETE,CREATE,DROP ON ShaTuDB.* TO 'ShaTuTs'@'localhost';
 
--- Add tables to new database
+/* ********** ADD TABLES TO NEW DATABASE ********** */
 USE ShaTuDB;
 
 CREATE TABLE Account (
-   UserId VARCHAR(256),
-   Password VARCHAR(256) NOT NULL,
-   FirstName VARCHAR(256),
-   LastName VARCHAR(256),
-   Question int,
-   Answer VARCHAR(256),
-   IsStudent tinyint DEFAULT 0,
-   PRIMARY KEY (UserId)
+    UserId VARCHAR(256) PRIMARY KEY,
+    Password VARCHAR(256) NOT NULL,
+    FirstName VARCHAR(256),
+    LastName VARCHAR(256),
+    Question INT,
+    Answer VARCHAR(256),
+    IsStudent TINYINT DEFAULT 0
+);
+
+CREATE TABLE Assessment (
+    AssessmentId INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    UserId VARCHAR(256) NOT NULL,
+    KnowledgeComponentId INT NOT NULL,
+    AssessmentLevel VARCHAR(32) NOT NULL,
+    Exposures INT,
+    Successes INT,
+    Hints INT
+);
+
+-- Truncate Table Assessment;
+-- Will delete data, but also reset the next id counter to zero
+
+CREATE TABLE Course (
+    CourseId INT NOT NULL DEFAULT 0 PRIMARY KEY,
+    Title VARCHAR(255) DEFAULT NULL,
+    PrimaryPedagogy VARCHAR(255) DEFAULT NULL,
+    Description VARCHAR(255) DEFAULT NULL
+);
+
+CREATE TABLE ExercisingLocation (
+    ExercisingLocationId INT NOT NULL PRIMARY KEY,
+    CourseId INT,
+    UnitId INT,
+    TaskId INT,
+    StepId INT
+);
+
+CREATE TABLE Hint (
+    HintId INT NOT NULL DEFAULT 0 PRIMARY KEY,
+    StepId INT NOT NULL,
+    Text VARCHAR(256) DEFAULT NULL,
+    SequenceIndex INT DEFAULT NULL
+);
+
+CREATE TABLE InfoMsgStep (
+    SubStepId INT NOT NULL PRIMARY KEY,
+    Text VARCHAR(4096)
+);
+
+CREATE TABLE KnowledgeComponent (
+    KnowledgeComponentId INT NOT NULL PRIMARY KEY,
+    CourseId INT NOT NULL,
+    Title VARCHAR(256) NOT NULL,
+    Description VARCHAR(255),
+    BloomLevel VARCHAR(256) NOT NULL,
+    IsDomainFocus TINYINT,
+    Pedagogy VARCHAR(256),
+    ExercisingLocations VARCHAR(256),
+    Granularity VARCHAR(256)
+);
+
+CREATE TABLE PendingStep (
+    PendingStepId INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    SessionId INT NOT NULL,
+    StepId INT NOT NULL,
+    NotifyTutor TINYINT DEFAULT 0,
+    IsCompleted TINYINT DEFAULT 0,
+    CurrentHintIndex INT NOT NULL
+);
+
+CREATE TABLE PendingTask (
+    SessionId INT NOT NULL PRIMARY KEY,
+    TaskId INT NOT NULL,
+    PendingStepId INT NOT NULL
 );
 
 CREATE TABLE Problem (
-	ProblemId INT AUTO_INCREMENT PRIMARY KEY,
+    ProblemId INT PRIMARY KEY,
     Title VARCHAR(256) NOT NULL,
     Description VARCHAR(256) NOT NULL,
     Message VARCHAR(512) NOT NULL
 );
 
-CREATE TABLE TutoringSession (
-    Id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
-    UserId VARCHAR(256) NOT NULL,
-    SecurityToken VARCHAR(256) NOT NULL,
-    IsActive TINYINT DEFAULT 0,
-    StartDate TIMESTAMP NOT NULL,
+CREATE TABLE Step (
+    StepId INT NOT NULL PRIMARY KEY,
     CourseId INT NOT NULL,
     UnitId INT NOT NULL,
-    ProblemId INT,
-    CONSTRAINT fk_tutoringsession_problemid
-		FOREIGN KEY (ProblemId)
-        REFERENCES Problem(ProblemId)
+    TaskId INT NOT NULL,
+    Title VARCHAR(256) DEFAULT NULL,
+    Description VARCHAR(256) DEFAULT NULL,
+    SequenceIndex INT DEFAULT NULL,
+    ExercisedComponentId INT,
+    StepSubType VARCHAR(256) DEFAULT NULL,
+    SubTypeId INT,
+    TimeoutId INT
 );
-
-CREATE TABLE PendingTask (
-  SessionId int NOT NULL,
-  TaskId int NOT NULL,
-  PendingStepId int NOT NULL,
-  PRIMARY KEY (SessionId)
-);
-
-CREATE TABLE PendingStep (
-  Id int NOT NULL AUTO_INCREMENT PRIMARY KEY,
-  SessionId int NOT NULL,
-  StepId int NOT NULL,
-  NotifyTutor tinyint DEFAULT 0,
-  IsCompleted tinyint DEFAULT 0,
-  CurrentHintIndex int NOT NULL
-);
-
-
 
 CREATE TABLE Student (
-   UserId VARCHAR(255),
-   FirstName VARCHAR(30) NOT NULL,
-   LastName VARCHAR(255) NOT NULL
+    UserId VARCHAR(255),
+    FirstName VARCHAR(30) NOT NULL,
+    LastName VARCHAR(255) NOT NULL
 );
 
 CREATE TABLE StudentModel (
-   UserId VARCHAR(255) NOT NULL PRIMARY KEY,
-   ScaffoldLevel VARCHAR(16) NOT NULL
+    UserId VARCHAR(255) NOT NULL PRIMARY KEY,
+    ScaffoldLevel VARCHAR(16) NOT NULL
 );
 
-CREATE TABLE Course (
-  Id int NOT NULL DEFAULT '0',
-  Title varchar(255) DEFAULT NULL,
-  PrimaryPedagogy varchar(255) DEFAULT NULL,
-  Description varchar(255) DEFAULT NULL,
-  PRIMARY KEY (Id));
-
-CREATE TABLE Unit (
-  UnitId int NOT NULL DEFAULT '0',
-  CourseId int DEFAULT NULL,
-  Title varchar(255) DEFAULT NULL,
-  Description varchar(255) DEFAULT NULL,
-  SequenceIndex int DEFAULT NULL,
-  Pedagogy varchar(255) DEFAULT NULL,
-  PRIMARY KEY (UnitId));
-
-# A static description of a task to complete within a course unit.
+-- A static description of a task to complete within a course unit.
+-- Should ExampleType be ProblemType instead?
 CREATE TABLE Task (
-	TaskId INT NOT NULL DEFAULT 0,
+    TaskId INT NOT NULL DEFAULT 0 PRIMARY KEY,
     CourseId INT NOT NULL DEFAULT 1,
     UnitId INT DEFAULT NULL,
     Title VARCHAR(256) NOT NULL,
     Description VARCHAR(256) NOT NULL,
     Kind ENUM('PROBLEM', 'MESSAGE') NOT NULL,
     SequenceIndex INT,
-    ExampleType VARCHAR(256) DEFAULT NULL,
-    ProblemId INT,
-    PRIMARY KEY (TaskId),
-    CONSTRAINT fk_task_problemid
-		FOREIGN KEY (ProblemId)
-        REFERENCES Problem(ProblemId)
+    ExampleType ENUM(
+        'ASCII_ENCODE', 'ADD_ONE_BIT', 'PAD_ZEROS', 'ADD_MSG_LENGTH', 'PREPARE_SCHEDULE', 'INITIALIZE_VARS',
+        'COMPRESS_ROUND', 'ROTATE_BITS', 'SHIFT_BITS', 'XOR_BITS', 'ADD_BITS', 'MAJORITY_FUNCTION', 'CHOICE_FUNCTION',
+        'SHA_ZERO', 'SHA_ONE', 'STEP_COMPLETION_REPLY', 'REQUEST_HINT', 'DEFAULT'),
+    ProblemId INT
 );
-
-CREATE TABLE Step (
-  Id int NOT NULL,
-  CourseId int NOT NULL,
-  UnitId int NOT NULL,
-  TaskId int NOT NULL,
-  Title varchar(256) DEFAULT NULL,
-  Description varchar(256) DEFAULT NULL,
-  SequenceIndex int DEFAULT NULL,
-  ExercisedComponentId int,
-  StepSubType varchar(256) DEFAULT NULL,
-  SubTypeId int,
-  TimeoutId int,
-  PRIMARY KEY (Id));
-
-CREATE TABLE InfoMsgStep (
-  SubStepId int NOT NULL,
-  Text varchar(4096),
-  PRIMARY KEY(SubStepId));
 
 CREATE TABLE Timeout (
-  id int NOT NULL,
-  TimeoutType varchar(256),
-  Seconds int,
-  Event varchar(256),
-  Msg varchar(4096),
-  PRIMARY KEY(id));
-
-CREATE TABLE KnowledgeComponent (
-  Id int NOT NULL ,
-  CourseId int NOT NULL,
-  Title varchar(256) NOT NULL,
-  Description varchar(255),
-  BloomLevel varchar(256) NOT NULL,
-  IsDomainFocus tinyint,
-  Pedagogy varchar(256),
-  ExercisingLocations varchar(256),
-  Granularity varchar(256),
-  PRIMARY KEY (Id));
-
-CREATE TABLE ExercisingLocation (
-  Id int NOT NULL,
-  CourseId int,
-  UnitId int,
-  TaskId int,
-  StepId int,
-  PRIMARY KEY (Id));
-
-CREATE TABLE Hint (
-  Id int NOT NULL DEFAULT '0',
-  StepId int NOT NULL,
-  Text varchar(256) DEFAULT NULL,
-  SequenceIndex int DEFAULT NULL,
-  PRIMARY KEY (Id));
-
-CREATE TABLE Assessment (
-   Id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
-   UserId VARCHAR(256) NOT NULL,
-   KnowledgeComponentId INT NOT NULL,
-   AssessmentLevel VARCHAR(32) NOT NULL,
-   Exposures INT,
-   Successes INT,
-   Hints INT
+    TimeoutId INT NOT NULL PRIMARY KEY,
+    TimeoutType VARCHAR(256),
+    Seconds INT,
+    Event VARCHAR(256),
+    Msg VARCHAR(4096)
 );
 
--- Truncate Table Assessment;
--- Will delete data, but also reset the next id counter to zero
+CREATE TABLE TutoringSession (
+    TutoringSessionId INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    UserId VARCHAR(256) NOT NULL,
+    SecurityToken VARCHAR(256) NOT NULL,
+    IsActive TINYINT DEFAULT 0,
+    StartDate TIMESTAMP NOT NULL,
+    CourseId INT NOT NULL,
+    UnitId INT NOT NULL,
+    ProblemId INT
+);
 
--- Populate tables
+CREATE TABLE Unit (
+    UnitId INT NOT NULL DEFAULT 0 PRIMARY KEY,
+    CourseId INT DEFAULT NULL,
+    Title VARCHAR(255) DEFAULT NULL,
+    Description VARCHAR(255) DEFAULT NULL,
+    SequenceIndex INT DEFAULT NULL,
+    Pedagogy VARCHAR(255) DEFAULT NULL
+);
 
-INSERT INTO Course
-(Id,
- Title,
- PrimaryPedagogy,
- Description)
-VALUES
-(1,'SHA-256 Message Digest', 'Fixed Sequence', 
-  'Familiarizes students with the operation of the SHA-256 message digest
-        algorithm along with its underlying bitwise operations and encodings.');
+/* ********** POPULATE TABLES ********** */
 
--- This problem will be referenced by the first row in task
-INSERT INTO Problem (Title, Description, Message)
+INSERT INTO Course (
+    CourseId, Title, PrimaryPedagogy,
+    Description)
 VALUES (
-	'Introductory Problem',
-    'Introduces the student to the tutor.',
-    'Regis Computer Science Rocks!'
+    1, 'SHA-256 Message Digest', 'Fixed Sequence',
+    'Familiarizes students with the operation of the SHA-256 message digest algorithm along with its underlying bitwise operations and encodings.');
+
+INSERT INTO ExercisingLocation (ExercisingLocationId, CourseId, UnitId, TaskId, StepId)
+VALUES (0,1,0,0,0);
+
+INSERT INTO Hint (HintId, StepId, Text, SequenceIndex)
+VALUES (0, 0, 'Acknowledge this message by pressing the Acknowledged button.', 0);
+
+INSERT INTO InfoMsgStep (
+    SubStepId, Text)
+VALUES (
+    0, CONCAT('Welcome, I''m ShaTu. I''ll begin by showing you how this application works by demonstrating each step used to create a ',
+        'SHA-256 message digest including the bitwise operations associated with these steps.\n\nWhen I send you an information message, ',
+        'like this one, all you have to do is acknowledge it by pressing the ''Acknowledged'' button.')
 );
 
-INSERT INTO Unit
-(UnitId,
-CourseId,
-Title,
-Description,
-SequenceIndex,
-Pedagogy)
-VALUES
-(0, 1, 'SHA-256: See One', 
-  'In this unit, the student will see an example of how each primary
-            step of the SHA-256 algorithm is performed. It also exposes the
-            student to the general operation of the ShaTu application.', 
+INSERT INTO KnowledgeComponent (
+    KnowledgeComponentId, CourseId, Title, Description,
+    BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
+VALUES (
+    0, 1, 'Information Message Acknowledgement', 'Student has appropriately demonstrated acknowleding information messages presented by the tutor.',
+    'Application', 0, 'Other', '0', 'Knowledge Component');
+
+INSERT INTO KnowledgeComponent (
+    KnowledgeComponentId, CourseId, Title, Description,
+    BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
+VALUES (
+    10, 1, 'Step Completion Reply', 'Student has appropriately demonstrated step completion.',
+    'Application', 0, 'Other', '0', 'Knowledge Component');
+
+INSERT INTO KnowledgeComponent (
+    KnowledgeComponentId, CourseId, Title, Description, BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
+VALUES (
+    20, 1, 'Hint Request', 'Student has appropriately requested a step hint.', 'Application', 0, 'Other', '0', 'Knowledge Component');
+
+INSERT INTO KnowledgeComponent (
+    KnowledgeComponentId, CourseId, Title, Description,
+    BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
+VALUES (
+    100, 1, 'Encode ASCII', 'Convert an English Text String into its ASCII equivalent.',
+    'Application', 0, 'Other', '0', 'Knowledge Component');
+
+INSERT INTO KnowledgeComponent (
+    KnowledgeComponentId, CourseId, Title, Description, BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
+VALUES (
+    101, 1, 'Encode Hex', 'Convert to Hex equivalent', 'Application', 0, 'Other', '0', 'Knowledge Component');
+
+INSERT INTO KnowledgeComponent (
+    KnowledgeComponentId, CourseId, Title, Description, BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
+VALUES (
+    102, 1, 'Binary Hex', 'Convert to Binary equivalent', 'Application', 0, 'Other', '0', 'Knowledge Component');
+
+INSERT INTO KnowledgeComponent (
+    KnowledgeComponentId, CourseId, Title, Description, BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
+VALUES (
+    110, 1, 'Add One Bit', 'Add a single bit to the end of a bit string.', 'Application', 0, 'Other', '0', 'Knowledge Component');
+
+INSERT INTO KnowledgeComponent (
+    KnowledgeComponentId, CourseId, Title, Description, BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
+VALUES (
+    120, 1, 'Pad with Zeroes', 'Pad a bit string to the appropriate length with zeroes', 'Application', 0, 'Other', '0', 'Knowledge Component');
+
+INSERT INTO KnowledgeComponent (
+    KnowledgeComponentId, CourseId, Title, Description,
+    BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
+VALUES (
+    130, 1, 'Add a msg length to the bit string', 'Add the appropriate message length to the bit string',
+    'Application', 0, 'Other', '0', 'Knowledge Component');
+
+INSERT INTO KnowledgeComponent (
+    KnowledgeComponentId, CourseId, Title, Description, BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
+VALUES (
+    140, 1, 'Prepare Schedue', 'Prepare the schedule', 'Application', 0, 'Other', '0', 'Knowledge Component');
+
+INSERT INTO KnowledgeComponent (
+    KnowledgeComponentId, CourseId, Title, Description, BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
+VALUES (
+    150, 1, 'Initialize Variables', 'Initialize the compression round variables.', 'Application', 0, 'Other', '0', 'Knowledge Component');
+    
+INSERT INTO KnowledgeComponent (
+    KnowledgeComponentId, CourseId, Title, Description, BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
+VALUES (
+    160, 1, 'Compression Round', 'Sequence the Compression Round.', 'Application', 0, 'Other', '0', 'Knowledge Component');
+    
+INSERT INTO KnowledgeComponent (
+    KnowledgeComponentId, CourseId, Title, Description, BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
+VALUES (
+    170, 1, 'Rotate BIts', 'Rotate a bit string.', 'Application', 0, 'Other', '0', 'Knowledge Component');
+    
+INSERT INTO KnowledgeComponent (
+    KnowledgeComponentId, CourseId, Title, Description, BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
+VALUES (
+    180, 1, 'Shift Bits', 'Shift a bit string.', 'Application', 0, 'Other', '0', 'Knowledge Component');
+
+INSERT INTO KnowledgeComponent (
+    KnowledgeComponentId, CourseId, Title, Description, BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
+VALUES (
+    190, 1, 'XOR Bits', 'XOR a bit string.', 'Application', 0, 'Other', '0', 'Knowledge Component');
+    
+INSERT INTO KnowledgeComponent (
+    KnowledgeComponentId, CourseId, Title, Description, BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
+VALUES (
+    200, 1, 'Majority Function', 'Use the majority function on appropriate bit strings.', 'Application', 0, 'Other', '0', 'Knowledge Component');
+
+INSERT INTO KnowledgeComponent (
+    KnowledgeComponentId, CourseId, Title, Description, BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
+VALUES (
+    210, 1, 'Choice Function', 'Demonstrate the choice function on appropriate bit strings.', 'Application', 0, 'Other', '0', 'Knowledge Component'); 
+
+INSERT INTO KnowledgeComponent (
+    KnowledgeComponentId, CourseId, Title, Description, BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
+VALUES (
+    220, 1, 'Add bit strings', 'Demonstrate the ability to add two bit strings together.', 'Application', 0, 'Other', '0', 'Knowledge Component');
+
+INSERT INTO KnowledgeComponent (
+    KnowledgeComponentId, CourseId, Title, Description, BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
+VALUES (
+    230, 1, 'SHA Sum 0 Function', 'Use the Sigma0 function.', 'Application', 0, 'Other', '0', 'Knowledge Component');
+
+-- This problem will be referenced by the Encode as ASCII task
+INSERT INTO Problem (ProblemId, Title, Description, Message)
+VALUES (1, 'Introductory Problem', 'Introduces the student to the tutor.', 'Regis Computer Science Rocks!');
+
+INSERT INTO Step (StepId, CourseId, UnitId, TaskId, Title, Description, SequenceIndex, ExercisedComponentId, StepSubType, SubTypeId, TimeoutId)
+VALUES (0, 1, 0, 0, 'Acknowledge Welcome', 'First Step in learning the tutor', 0, 0, 'Information Message', 0, 0);
+
+INSERT INTO Task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
+VALUES (0, 1, 0, 'Welcome', 'Let''s get started', 'MESSAGE', 0, 'DEFAULT', NULL);
+
+INSERT INTO Task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
+VALUES (10, 1, 0, 'Encode ASCII', 'Convert an English Text String into its ASCII equivalent.', 'PROBLEM', 1, 'ASCII_ENCODE', 1);
+
+INSERT INTO Task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
+VALUES (20, 1, 0, 'Add One Bit', 'Add a single bit to the end of a bit string.', 'PROBLEM', 2, 'ADD_ONE_BIT', NULL);
+
+INSERT INTO Task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
+VALUES (30, 1, 0, 'Pad with Zeroes', 'Pad a bit string to the appropriate length with zeroes', 'PROBLEM', 3, 'PAD_ZEROS', NULL);
+
+INSERT INTO Task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
+VALUES (40, 1, 0, 'Add a msg length to the bit string', 'Add the appropriate message length to the bit string', 'PROBLEM', 4, 'ADD_MSG_LENGTH', NULL);
+
+INSERT INTO Task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
+VALUES (50, 1, 0, 'Prepare Schedule', 'Prepare the schedule', 'PROBLEM', 5, 'PREPARE_SCHEDULE', NULL);
+
+INSERT INTO Task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
+VALUES (60, 1, 0, 'Initialize Variables', 'Initialize the compression round variables.', 'PROBLEM', 6, 'INITIALIZE_VARS', NULL);
+
+INSERT INTO Task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
+VALUES (70, 1, 0, 'Compression Round', 'Sequence the Compression Round.', 'PROBLEM', 7, 'COMPRESS_ROUND', NULL);
+
+INSERT INTO Task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
+VALUES (80, 1, 0, 'Rotate Bits', 'Rotate a bit string.', 'PROBLEM', 8, 'ROTATE_BITS', NULL);
+
+INSERT INTO Task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
+VALUES (90, 1, 0, 'Shift Bits', 'Shift a bit string.', 'PROBLEM', 9, 'SHIFT_BITS', NULL);
+
+INSERT INTO Task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
+VALUES (100, 1, 0, 'XOR Bits', 'XOR a bit string.', 'PROBLEM', 10, 'XOR_BITS', NULL);
+
+INSERT INTO Task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
+VALUES (110, 1, 0, 'Choice Function', 'Demonstrate the choice function on appropriate bit strings.', 'PROBLEM', 11, 'CHOICE_FUNCTION', NULL);
+
+INSERT INTO Task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
+VALUES (120, 1, 0, 'Majority Function', 'Use the majority function on appropriate bit strings.', 'PROBLEM', 12, 'MAJORITY_FUNCTION', NULL);
+
+INSERT INTO Task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
+VALUES (130, 1, 0, 'Encode ASCII', 'Convert an English Text String into its ASCII equivalent.', 'PROBLEM', 13, 'ASCII_ENCODE', NULL);
+
+INSERT INTO Task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
+VALUES (140, 1, 0, 'SHA Sum 0 Function', 'Use the Sigma0 function.', 'PROBLEM', 14, 'SHA_ZERO', NULL);
+
+INSERT INTO Timeout (TimeoutId, TimeoutType, Seconds, Event, Msg)
+VALUES (0, 'Info Message', 60, 'Reminder', 'Please acknowledge the current information message to continue.');
+
+INSERT INTO Unit (
+    UnitId, CourseId, Title,
+    Description,
+    SequenceIndex, Pedagogy)
+VALUES (
+    0, 1, 'SHA-256: See One',
+    CONCAT('In this unit, the student will see an example of how each primary step of the SHA-256 algorithm is performed. ',
+        'It also exposes the student to the general operation of the ShaTu application.'),
     0, 'Fixed Sequence');
 
--- The first task directly references the first row in Problem with ProblemId = 1
-INSERT INTO Task
-(TaskId,
-CourseId,
-UnitId,
-Title,
-Description,
-Kind,
-SequenceIndex,
-ExampleType,
-ProblemId)
-VALUES
-(0, 1, 0, 'Welcome', 'Let''s get started', 'PROBLEM', 0, 'N/A', 1);
+/* ********** ADD FOREIGN KEY CONSTRAINTS ********** */
 
+ALTER Table Assessment
+ADD CONSTRAINT fk_assessment_userid
+FOREIGN KEY (UserId) REFERENCES Account(UserId)
+ON UPDATE CASCADE ON DELETE CASCADE;
 
-INSERT INTO Step
-(Id,
- CourseId,
- UnitId,
- TaskId,
- Title,
- Description,
- SequenceIndex,
- ExercisedComponentId,
- StepSubType,
- SubTypeId,  
- TimeoutId)
-VALUES
-(0, 1, 0, 0, 'Acknowledge Welcome', 
- 'First Step in learning the tutor', 0, 0, 'Information Message', 0, 0);
+ALTER Table Assessment
+ADD CONSTRAINT fk_assessment_knowledgecomponentid
+FOREIGN KEY (KnowledgeComponentId) REFERENCES KnowledgeComponent(KnowledgeComponentId)
+ON UPDATE CASCADE ON DELETE CASCADE;
 
-INSERT INTO InfoMsgStep (SubStepId, Text) VALUES
- (0, 'Welcome, I''m ShaTu. I''ll begin by showing you how this
-     application works by demonstrating each step used to create
-     an SHA-256 message digest including the bitwise operations
-     associated with these steps.\n\n
-     When I send you an information message, like this one, all you
-     have to do is acknowledge it by pressing the ''Acknowledged'' button.');
+ALTER Table ExercisingLocation
+ADD CONSTRAINT fk_exercisinglocation_courseid
+FOREIGN KEY (CourseId) REFERENCES Course(CourseId)
+ON UPDATE CASCADE ON DELETE SET NULL;  -- Currently nullable in table definition
 
-INSERT INTO Timeout (id, TimeoutType, Seconds, Event, Msg) VALUES
- (0, 'Info Message', 60, 'Reminder', 'Please acknowledge the current information message to continue.');
+ALTER Table ExercisingLocation
+ADD CONSTRAINT fk_exercisinglocation_stepid
+FOREIGN KEY (StepId) REFERENCES Step(StepId)
+ON UPDATE CASCADE ON DELETE SET NULL;  -- Currently nullable in table definition
 
-INSERT INTO Hint
-(Id,
- StepId,
- Text,
- SequenceIndex)
-VALUES
-(0, 0, 'Acknowledge this message by pressing the ''Acknowledged'' button.', 0);
+ALTER Table ExercisingLocation
+ADD CONSTRAINT fk_exercisinglocation_taskid
+FOREIGN KEY (TaskId) REFERENCES Task(TaskId)
+ON UPDATE CASCADE ON DELETE SET NULL;  -- Currently nullable in table definition
 
-INSERT INTO KnowledgeComponent
-(Id, CourseId, Title,
- Description,
- BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
-VALUES
-(0, 1, 'Information Message Acknowledgement', 
- 'Student has appropriately demonstrated acknowleding information messages presented by the tutor.',
- 'Application', 0, 'Other', '0', 'Knowledge Component');
+ALTER Table ExercisingLocation
+ADD CONSTRAINT fk_exercisinglocation_unitid
+FOREIGN KEY (UnitId) REFERENCES Unit(UnitId)
+ON UPDATE CASCADE ON DELETE SET NULL;  -- Currently nullable in table definition
 
-INSERT INTO KnowledgeComponent
-(Id, CourseId, Title,
- Description,
- BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
-VALUES
-(10, 1, 'Step Completion Reply', 
- 'Student has appropriately demonstrated step completion.',
- 'Application', 0, 'Other', '0', 'Knowledge Component');
+ALTER Table Hint
+ADD CONSTRAINT fk_hint_stepid
+FOREIGN KEY (StepId) REFERENCES Step(StepId)
+ON UPDATE CASCADE ON DELETE CASCADE;
 
-INSERT INTO KnowledgeComponent
-(Id, CourseId, Title,
- Description,
- BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
-VALUES
-(20, 1, 'Hint Request', 
- 'Student has appropriately requested a step hint.',
- 'Application', 0, 'Other', '0', 'Knowledge Component');
+ALTER Table KnowledgeComponent
+ADD CONSTRAINT fk_knowledgecomponent_courseid
+FOREIGN KEY (CourseId) REFERENCES Course(CourseId)
+ON UPDATE CASCADE ON DELETE CASCADE;
 
-INSERT INTO KnowledgeComponent
-(Id, CourseId, Title,
- Description,
- BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
-VALUES
-(100, 1, 'Encode ASCII', 
- 'Convert an English Text String into its ASCII equivalent.',
- 'Application', 0, 'Other', '0', 'Knowledge Component');
+ALTER Table PendingStep
+ADD CONSTRAINT fk_pendingstep_sessionid
+FOREIGN KEY (SessionId) REFERENCES TutoringSession(TutoringSessionId)
+ON UPDATE CASCADE ON DELETE CASCADE;
 
-INSERT INTO KnowledgeComponent
-(Id, CourseId, Title,
- Description,
- BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
-VALUES
-(101, 1, 'Encode Hex', 
- 'Convert to Hex equivalent',
- 'Application', 0, 'Other', '0', 'Knowledge Component');
+ALTER Table PendingStep
+ADD CONSTRAINT fk_pendingstep_stepid
+FOREIGN KEY (StepId) REFERENCES Step(StepId)
+ON UPDATE CASCADE ON DELETE CASCADE;
 
-INSERT INTO KnowledgeComponent
-(Id, CourseId, Title,
- Description,
- BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
-VALUES
-(102, 1, 'Binary Hex', 
- 'Convert to Binary equivalent',
- 'Application', 0, 'Other', '0', 'Knowledge Component');
+ALTER Table PendingTask
+ADD CONSTRAINT fk_pendingtask_pendingstepid
+FOREIGN KEY (PendingStepId) REFERENCES PendingStep(PendingStepId)
+ON UPDATE CASCADE ON DELETE CASCADE;
 
-INSERT INTO KnowledgeComponent
-(Id, CourseId, Title,
- Description,
- BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
-VALUES
-(110, 1, 'Add One Bit', 
- 'Add a single bit to the end of a bit string.',
- 'Application', 0, 'Other', '0', 'Knowledge Component');
+ALTER Table PendingTask
+ADD CONSTRAINT fk_pendingtask_taskid
+FOREIGN KEY (TaskId) REFERENCES Task(TaskId)
+ON UPDATE CASCADE ON DELETE CASCADE;
 
-INSERT INTO KnowledgeComponent
-(Id, CourseId, Title,
- Description,
- BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
-VALUES
-(120, 1, 'Pad with Zeroes', 
- 'Pad a bit string to the appropriate length with zeroes',
- 'Application', 0, 'Other', '0', 'Knowledge Component');
+ALTER Table Step
+ADD CONSTRAINT fk_step_courseid
+FOREIGN KEY (CourseId) REFERENCES Course(CourseId)
+ON UPDATE CASCADE ON DELETE CASCADE;
 
-INSERT INTO KnowledgeComponent
-(Id, CourseId, Title,
- Description,
- BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
-VALUES
-(130, 1, 'Add a msg length to the bit string', 
- 'Add the appropriate message length to the bit string',
- 'Application', 0, 'Other', '0', 'Knowledge Component');
+ALTER Table Step
+ADD CONSTRAINT fk_step_unitid
+FOREIGN KEY (UnitId) REFERENCES Unit(UnitId)
+ON UPDATE CASCADE ON DELETE CASCADE;
 
-INSERT INTO KnowledgeComponent
-(Id, CourseId, Title,
- Description,
- BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
-VALUES
-(140, 1, 'Prepare Schedue', 
- 'Prepare the schedule',
- 'Application', 0, 'Other', '0', 'Knowledge Component');
+ALTER Table Step
+ADD CONSTRAINT fk_step_taskid
+FOREIGN KEY (TaskId) REFERENCES Task(TaskId)
+ON UPDATE CASCADE ON DELETE CASCADE;
 
-INSERT INTO KnowledgeComponent
-(Id, CourseId, Title,
- Description,
- BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
-VALUES
-(150, 1, 'Initialize Variables', 
- 'Initialize the compression round variables.',
- 'Application', 0, 'Other', '0', 'Knowledge Component');
-    
-INSERT INTO KnowledgeComponent
-(Id, CourseId, Title,
- Description,
- BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
-VALUES
-(160, 1, 'Compression Round', 
- 'Sequence the Compression Round.',
- 'Application', 0, 'Other', '0', 'Knowledge Component');
-    
-INSERT INTO KnowledgeComponent
-(Id, CourseId, Title,
- Description,
- BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
-VALUES
-(170, 1, 'Rotate BIts', 
- 'Rotate a bit string.',
- 'Application', 0, 'Other', '0', 'Knowledge Component');
-    
-INSERT INTO KnowledgeComponent
-(Id, CourseId, Title,
- Description,
- BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
-VALUES
-(180, 1, 'Shift Bits', 
- 'Shift a bit string.',
- 'Application', 0, 'Other', '0', 'Knowledge Component');
-    
-INSERT INTO KnowledgeComponent
-(Id, CourseId, Title,
- Description,
- BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
-VALUES
-(190, 1, 'XOR Bits', 
- 'XOR a bit string.',
- 'Application', 0, 'Other', '0', 'Knowledge Component');
-    
-INSERT INTO KnowledgeComponent
-(Id, CourseId, Title,
- Description,
- BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
-VALUES
-(200, 1, 'Majority Function', 
- 'Use the majority function on appropriate bit strings.',
- 'Application', 0, 'Other', '0', 'Knowledge Component');
+ALTER Table Step
+ADD CONSTRAINT fk_step_timeoutid
+FOREIGN KEY (TimeoutId) REFERENCES Timeout(TimeoutId)
+ON UPDATE CASCADE ON DELETE SET NULL;  -- Currently nullable in table definition
 
-INSERT INTO KnowledgeComponent
-(Id, CourseId, Title,
- Description,
- BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
-VALUES
-(210, 1, 'Choice Function', 
- 'Demonstrate the choice function on appropriate bit strings.',
- 'Application', 0, 'Other', '0', 'Knowledge Component'); 
+ALTER Table Task
+ADD CONSTRAINT fk_task_courseid
+FOREIGN KEY (CourseId) REFERENCES Course(CourseId)
+ON UPDATE CASCADE ON DELETE CASCADE;
 
-INSERT INTO KnowledgeComponent
-(Id, CourseId, Title,
- Description,
- BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
-VALUES
-(220, 1, 'Add bit strings', 
- 'Demonstrate the ability to add two bit strings together.',
- 'Application', 0, 'Other', '0', 'Knowledge Component');
+ALTER Table Task
+ADD CONSTRAINT fk_task_problemid
+FOREIGN KEY (ProblemId) REFERENCES Problem(ProblemId)
+ON UPDATE CASCADE ON DELETE CASCADE;
 
-INSERT INTO KnowledgeComponent
-(Id, CourseId, Title,
- Description,
- BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity)
-VALUES
-    (230, 1, 'SHA Sum 0 Function',
-     'Use the Sigma0 function.',
-     'Application', 0, 'Other', '0', 'Knowledge Component');
+ALTER Table Task
+ADD CONSTRAINT fk_task_unitid
+FOREIGN KEY (UnitId) REFERENCES Unit(UnitId)
+ON UPDATE CASCADE ON DELETE SET NULL;  -- Currently nullable in table definition
 
-INSERT INTO task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
-VALUES (10, 1, 0, 'Encode ASCII', 'Convert an English Text String into its ASCII equivalent.', 'PROBLEM', 1, 'N/A', NULL);
+ALTER Table TutoringSession
+ADD CONSTRAINT fk_tutoringsession_courseid
+FOREIGN KEY (CourseId) REFERENCES Course(CourseId)
+ON UPDATE CASCADE ON DELETE CASCADE;
 
-INSERT INTO task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
-VALUES (20, 1, 0, 'Add One Bit', 'Add a single bit to the end of a bit string.', 'PROBLEM', 2, 'N/A', NULL);
+ALTER Table TutoringSession
+ADD CONSTRAINT fk_tutoringsession_problemid
+FOREIGN KEY (ProblemId) REFERENCES Problem(ProblemId)
+ON UPDATE CASCADE ON DELETE SET NULL;    -- Deleting a problem should not delete a session
 
-INSERT INTO task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
-VALUES (30, 1, 0, 'Pad with Zeroes', 'Pad a bit string to the appropriate length with zeroes', 'PROBLEM', 3, 'N/A', NULL);
+ALTER Table TutoringSession
+ADD CONSTRAINT fk_tutoringsession_unitid
+FOREIGN KEY (UnitId) REFERENCES Unit(UnitId)
+ON UPDATE CASCADE ON DELETE CASCADE;
 
-INSERT INTO task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
-VALUES (40, 1, 0, 'Add a msg length to the bit string', 'Add the appropriate message length to the bit string', 'PROBLEM', 4, 'N/A', NULL);
+ALTER Table TutoringSession
+ADD CONSTRAINT fk_tutoringsession_userid
+FOREIGN KEY (UserId) REFERENCES Account(UserId)
+ON UPDATE CASCADE ON DELETE CASCADE;
 
-INSERT INTO task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
-VALUES (50, 1, 0, 'Prepare Schedule', 'Prepare the schedule', 'PROBLEM', 5, 'N/A', NULL);
+ALTER Table Unit
+ADD CONSTRAINT fk_unit_courseid
+FOREIGN KEY (CourseId) REFERENCES Course(CourseId)
+ON UPDATE CASCADE ON DELETE CASCADE;
 
-INSERT INTO task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
-VALUES (60, 1, 0, 'Initialize Variables', 'Initialize the compression round variables.', 'PROBLEM', 6, 'N/A', NULL);
-
-INSERT INTO task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
-VALUES (70, 1, 0, 'Compression Round', 'Sequence the Compression Round.', 'PROBLEM', 7, 'N/A', NULL);
-
-INSERT INTO task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
-VALUES (80, 1, 0, 'Rotate BIts', 'Rotate a bit string.', 'PROBLEM', 8, 'N/A', NULL);
-
-INSERT INTO task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
-VALUES (90, 1, 0, 'Shift Bits', 'Shift a bit string.', 'PROBLEM', 9, 'N/A', NULL);
-
-INSERT INTO task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
-VALUES (100, 1, 0, 'XOR Bits', 'XOR a bit string.', 'PROBLEM', 10, 'N/A', NULL);
-
-INSERT INTO task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
-VALUES (110, 1, 0, 'Choice Function', 'Demonstrate the choice function on appropriate bit strings.', 'PROBLEM', 11, 'N/A', NULL);
-
-INSERT INTO task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
-VALUES (120, 1, 0, 'Majority Function', 'Use the majority function on appropriate bit strings.', 'PROBLEM', 12, 'N/A', NULL);
-
-INSERT INTO task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
-VALUES (130, 1, 0, 'Encode ASCII', 'Convert an English Text String into its ASCII equivalent.', 'PROBLEM', 13, 'N/A', NULL);
-
-INSERT INTO task (TaskId, CourseId, UnitId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId)
-VALUES (140, 1, 0, 'SHA Sum 0 Function', 'Use the Sigma0 function.', 'PROBLEM', 14, 'N/A', NULL);
-
-INSERT INTO ExercisingLocation
-(Id, CourseId, UnitId, TaskId, StepId)
-VALUES (0,1,0,0,0);

--- a/src/main/java/edu/regis/shatu/dao/CourseDAO.java
+++ b/src/main/java/edu/regis/shatu/dao/CourseDAO.java
@@ -34,12 +34,15 @@ import edu.regis.shatu.model.TaskSelectionKind;
 import edu.regis.shatu.model.Unit;
 import edu.regis.shatu.model.UnitDigest;
 import edu.regis.shatu.model.aol.OutcomeGranularity;
+import edu.regis.shatu.model.aol.Problem;
 import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.aol.StepSubType;
 import edu.regis.shatu.model.aol.TaskKind;
 import edu.regis.shatu.model.aol.Timeout;
 import edu.regis.shatu.model.steps.Step;
 import edu.regis.shatu.svc.CourseSvc;
+import edu.regis.shatu.svc.ProblemSvc;
+import edu.regis.shatu.svc.ServiceFactory;
 
 /**
  * An XML-based Data Access Object implementing CourseSvc behaviors.
@@ -52,7 +55,7 @@ public class CourseDAO extends MySqlDAO implements CourseSvc {
      * Instantiate this Course DAO with default values.
      */
     public CourseDAO() {
-        super("Course", "Id");
+        super("Course", "CourseId");
     }
 
     /**
@@ -60,7 +63,8 @@ public class CourseDAO extends MySqlDAO implements CourseSvc {
      */
     @Override
     public Course retrieve(int courseId) throws ObjNotFoundException, NonRecoverableException {
-        final String sql = "SELECT Title,PrimaryPedagogy,Description FROM Course WHERE Id = ?";
+        final String sql = "SELECT Title, PrimaryPedagogy, Description " + 
+                            "FROM Course WHERE CourseId = ?";
 
         Connection conn = null;
         PreparedStatement stmt = null;
@@ -102,7 +106,8 @@ public class CourseDAO extends MySqlDAO implements CourseSvc {
     public CourseDigest retrieveDigest(int courseId, Connection conn)
             throws ObjNotFoundException, NonRecoverableException {
 
-        final String sql = "SELECT Title,Description FROM Course WHERE Id = ?";
+        final String sql = "SELECT Title, Description " +
+                           "FROM Course WHERE CourseId = ?";
 
         PreparedStatement stmt = null;
 
@@ -138,7 +143,8 @@ public class CourseDAO extends MySqlDAO implements CourseSvc {
     public UnitDigest retrieveUnitDigest(int courseId, int unitId, Connection conn)
             throws ObjNotFoundException, NonRecoverableException {
 
-        final String sql = "SELECT Title,Description FROM Unit WHERE CourseId = ? AND UnitId = ?";
+        final String sql = "SELECT Title, Description " + 
+                           "FROM Unit WHERE CourseId = ? AND UnitId = ?";
 
         PreparedStatement stmt = null;
 
@@ -174,7 +180,9 @@ public class CourseDAO extends MySqlDAO implements CourseSvc {
     @Override
     public Task retrieveTask(int courseId, int taskId, Connection conn)
             throws ObjNotFoundException, NonRecoverableException {
-        final String sql = "SELECT Title,Description,Kind,SequenceIndex,ExampleType,ProblemId FROM Task WHERE CourseId = ? AND TaskId = ?";
+        final String sql = 
+                "SELECT Title, Description, Kind, SequenceIndex, ExampleType, ProblemId " + 
+                "FROM Task WHERE CourseId = ? AND TaskId = ?";
 
         PreparedStatement stmt = null;
 
@@ -224,7 +232,10 @@ public class CourseDAO extends MySqlDAO implements CourseSvc {
     private ArrayList<KnowledgeComponent> retrieveKnowledgeComponents(Course course, Connection conn)
             throws NonRecoverableException {
 
-        final String sql = "SELECT Id, Title, Description, BloomLevel, IsDomainFocus, Pedagogy, ExercisingLocations, Granularity FROM KnowledgeComponent WHERE CourseId = ?";
+        final String sql =
+                "SELECT KnowledgeComponentId, Title, Description, BloomLevel, " +
+                        "IsDomainFocus, Pedagogy, ExercisingLocations, Granularity " +
+                "FROM KnowledgeComponent WHERE CourseId = ?";
 
         ArrayList<KnowledgeComponent> outcomes = new ArrayList<>();
 
@@ -275,7 +286,8 @@ public class CourseDAO extends MySqlDAO implements CourseSvc {
      * @throws NonRecoverableException
      */
     private ArrayList<Unit> retrieveUnits(Course course, Connection conn) throws NonRecoverableException {
-        final String sql = "SELECT UnitId,Title,Description,SequenceIndex,Pedagogy FROM Unit WHERE CourseId = ?";
+        final String sql = "SELECT UnitId, Title, Description, SequenceIndex, Pedagogy " +
+                           "FROM Unit WHERE CourseId = ?";
 
         ArrayList<Unit> units = new ArrayList<>();
 
@@ -315,7 +327,10 @@ public class CourseDAO extends MySqlDAO implements CourseSvc {
      */
     private ArrayList<Task> retrieveTasks(Course course, Unit unit, Connection conn)
             throws NonRecoverableException {
-        final String sql = "SELECT TaskId,Title,Description,Kind,SequenceIndex,ExampleType,ProblemId FROM Task WHERE CourseId = ? AND UnitId = ?";
+        
+        final String sql = 
+                "SELECT TaskId, Title, Description, Kind, SequenceIndex, ExampleType, ProblemId " +
+                "FROM Task WHERE CourseId = ? AND UnitId = ?";
 
         ArrayList<Task> tasks = new ArrayList<>();
 
@@ -337,14 +352,33 @@ public class CourseDAO extends MySqlDAO implements CourseSvc {
                 task.setDescription(rs.getString(3));
                 task.setKind(TaskKind.findValue(rs.getString(4)));
                 task.setSequenceIndex(rs.getInt(5));
+                task.setType(ProblemType.valueOf(rs.getString(6)));
 
-                if (task.getKind() == TaskKind.PROBLEM) {
-                    task.setType(ProblemType.findValue(rs.getString(6)));
-                    // ToDo: What about problem id? (this is example type)
+                switch(task.getKind()){
+                    case MESSAGE:
+                        // ToDo: Handle MESSAGE kind tasks
+                        break;
+                    case PROBLEM:
+                        int problemId = rs.getInt(7);   // Returns 0 when NULL in DB
+                        
+                        if(!rs.wasNull()){
+                            ProblemSvc problemSvc = ServiceFactory.findProblemSvc();
+                            try {
+                                Problem problem = problemSvc.retrieve(problemId);
+                                task.setProblem(problem);
+                            }
+                            catch(ObjNotFoundException e){
+                                System.err.println("WARNING: ProblemId: " + problemId +
+                                        " not found for Task with TaskId: " + task.getId());
+                            }
+                        }
+                        break;
+                    default:
+                        break;
                 }
 
-                tasks.add(task);
-
+                tasks.add(task);    // Should this line go after task.setSteps()?
+                
                 task.setSteps(retrieveSteps(courseId, task.getId(), conn));
 
                 // ToDo: retrieve exercising locations
@@ -370,7 +404,10 @@ public class CourseDAO extends MySqlDAO implements CourseSvc {
      */
     private ArrayList<Step> retrieveSteps(int courseId, int taskId, Connection conn)
             throws NonRecoverableException {
-        final String sql = "SELECT Id,Title,Description,SequenceIndex,StepSubType,SubTypeId,TimeoutId FROM Step WHERE CourseId = ? AND TaskId = ?";
+        
+        final String sql =
+                "SELECT StepId, Title, Description, SequenceIndex, StepSubType, SubTypeId, TimeoutId " +
+                "FROM Step WHERE CourseId = ? AND TaskId = ?";
 
         ArrayList<Step> steps = new ArrayList<>();
 
@@ -420,7 +457,8 @@ public class CourseDAO extends MySqlDAO implements CourseSvc {
     private ArrayList<Hint> retrieveHints(int stepId, Connection conn)
             throws NonRecoverableException {
 
-        final String sql = "SELECT Id,Text,SequenceIndex FROM Hint WHERE StepId = ?";
+        final String sql = "SELECT HintId, Text, SequenceIndex " +
+                           "FROM Hint WHERE StepId = ?";
 
         ArrayList<Hint> hints = new ArrayList<>();
 
@@ -534,9 +572,9 @@ public class CourseDAO extends MySqlDAO implements CourseSvc {
         }
     }
 
-    private Timeout retrieveTimeout(int timeoutId, Connection conn)
-            throws NonRecoverableException {
-        final String sql = "SELECT TimeoutType,Seconds,Event,Msg FROM Timeout WHERE Id = ?";
+    private Timeout retrieveTimeout(int timeoutId, Connection conn) throws NonRecoverableException {
+        final String sql = "SELECT TimeoutType, Seconds, Event, Msg " +
+                           "FROM Timeout WHERE TimeoutId = ?";
 
         PreparedStatement stmt = null;
 
@@ -574,7 +612,8 @@ public class CourseDAO extends MySqlDAO implements CourseSvc {
     private ArrayList<ExercisingLocation> retrieveExercisingLocations(int courseId, Connection conn)
             throws NonRecoverableException {
 
-        final String sql = "SELECT Id, UnitId, TaskId, StepId FROM ExercisingLocation WHERE CourseId = ?";
+        final String sql = "SELECT ExercisingLocationId, UnitId, TaskId, StepId " +
+                           "FROM ExercisingLocation WHERE CourseId = ?";
 
         ArrayList<ExercisingLocation> locations = new ArrayList<>();
 

--- a/src/main/java/edu/regis/shatu/dao/SessionDAO.java
+++ b/src/main/java/edu/regis/shatu/dao/SessionDAO.java
@@ -50,7 +50,7 @@ import edu.regis.shatu.svc.SessionSvc;
 public class SessionDAO extends MySqlDAO implements SessionSvc, CRUD<TutoringSession> {
 
     public SessionDAO() {
-        super("TutoringSession", "Id");
+        super("TutoringSession", "TutoringSessionId");
     }
 
     /**
@@ -97,13 +97,11 @@ public class SessionDAO extends MySqlDAO implements SessionSvc, CRUD<TutoringSes
             ResultSet rs = stmt.getGeneratedKeys();
             if (rs.next()) {
                 session.setId(rs.getInt(1));
-                
                 createPendingTasks(session, conn);
             }
 
         } catch (SQLException e) {
             throw new NonRecoverableException("SessionDAO-ERR-1", e);
-
         } finally {
             close(conn, stmt);
         }
@@ -114,8 +112,10 @@ public class SessionDAO extends MySqlDAO implements SessionSvc, CRUD<TutoringSes
      */
     @Override
     public TutoringSession retrieve(String userId) throws ObjNotFoundException, NonRecoverableException {
-        final String sql = "SELECT Id, SecurityToken, IsActive, StartDate, CourseId, UnitId, ProblemId " +
-                           "FROM TutoringSession WHERE UserId = ?";
+        final String sql =
+                "SELECT TutoringSessionId, SecurityToken, IsActive, StartDate, " +
+                        "CourseId, UnitId, ProblemId " +
+                "FROM TutoringSession WHERE UserId = ?";
 
         Connection conn = null;
         PreparedStatement stmt = null;
@@ -212,7 +212,6 @@ public class SessionDAO extends MySqlDAO implements SessionSvc, CRUD<TutoringSes
 
             if (rs.next()) {
                 return rs.getString(1);
-
             } else {
                 throw new ObjNotFoundException("User Id:" + userId);
             }
@@ -232,7 +231,10 @@ public class SessionDAO extends MySqlDAO implements SessionSvc, CRUD<TutoringSes
      */
     @Override
     public void update(TutoringSession session) throws ObjNotFoundException, NonRecoverableException {
-        final String sql = "INSERT INTO TutoringSession (UserId, SecurityToken, IsActive, StartDate, CourseId, UnitId) VALUES (?,?,?,?,?,?)";
+        final String sql = 
+                "INSERT INTO TutoringSession " +
+                "(UserId, SecurityToken, IsActive, StartDate, CourseId, UnitId) " +
+                "VALUES (?,?,?,?,?,?)";
 
         Connection conn = null;
         PreparedStatement stmt = null;
@@ -261,13 +263,11 @@ public class SessionDAO extends MySqlDAO implements SessionSvc, CRUD<TutoringSes
             ResultSet rs = stmt.getGeneratedKeys();
             if (rs.next()) {
                 session.setId(rs.getInt(1));
-
                 createPendingTasks(session, conn);
             }
 
         } catch (SQLException e) {
             throw new NonRecoverableException("SessionDAO-ERR-1", e);
-
         } finally {
             close(conn, stmt);
         }
@@ -285,7 +285,10 @@ public class SessionDAO extends MySqlDAO implements SessionSvc, CRUD<TutoringSes
 
     private void createPendingTasks(TutoringSession session, Connection conn)
             throws NonRecoverableException {
-        final String sql = "INSERT INTO PendingTask (SessionId, TaskId, PendingStepId) VALUES (?,?,?)";
+        
+        final String sql = "INSERT INTO PendingTask " +
+                           "(SessionId, TaskId, PendingStepId) " +
+                           "VALUES (?,?,?)";
 
         int sessionId = session.getId();
 
@@ -305,10 +308,8 @@ public class SessionDAO extends MySqlDAO implements SessionSvc, CRUD<TutoringSes
                 stmt.executeUpdate();
 
             }
-
         } catch (SQLException e) {
             throw new NonRecoverableException("SessionDAO-ERR-7", e);
-
         } finally {
             close(stmt);
         }
@@ -316,7 +317,11 @@ public class SessionDAO extends MySqlDAO implements SessionSvc, CRUD<TutoringSes
 
     private int createPendingStep(int sessionId, PendingStep pStep, Connection conn)
             throws NonRecoverableException {
-        final String sql = "INSERT INTO PendingStep (SessionId, StepId, NotifyTutor, IsCompleted, CurrentHintIndex) VALUES (?,?,?,?,?)";
+        
+        final String sql =
+                "INSERT INTO PendingStep " +
+                "(SessionId, StepId, NotifyTutor, IsCompleted, CurrentHintIndex) " +
+                "VALUES (?,?,?,?,?)";
 
         PreparedStatement stmt = null;
 
@@ -343,7 +348,6 @@ public class SessionDAO extends MySqlDAO implements SessionSvc, CRUD<TutoringSes
 
         } catch (SQLException e) {
             throw new NonRecoverableException("SessionDAO-ERR-9", e);
-
         } finally {
             close(stmt);
         }
@@ -392,7 +396,6 @@ public class SessionDAO extends MySqlDAO implements SessionSvc, CRUD<TutoringSes
             throw new NonRecoverableException("SessionDAO-ERR-10", new InconsistentDBException(errMsg));
         } catch (SQLException e) {
             throw new NonRecoverableException("SessionDAO-ERR-11", e);
-
         } finally {
             close(stmt);
         }
@@ -401,7 +404,8 @@ public class SessionDAO extends MySqlDAO implements SessionSvc, CRUD<TutoringSes
     public PendingStep retrievePendingStep(int pendingStepId, int sessionId, Task task, Connection conn)
             throws NonRecoverableException {
 
-        final String sql = "SELECT StepId, NotifyTutor, IsCompleted, CurrentHintIndex FROM PendingStep WHERE Id = ?";
+        final String sql = "SELECT StepId, NotifyTutor, IsCompleted, CurrentHintIndex " +
+                           "FROM PendingStep WHERE PendingStepId = ?";
 
         PreparedStatement stmt = null;
 
@@ -426,7 +430,6 @@ public class SessionDAO extends MySqlDAO implements SessionSvc, CRUD<TutoringSes
 
         } catch (SQLException e) {
             throw new NonRecoverableException("SessionDAO-ERR-13", e);
-
         } finally {
             close(stmt);
         }

--- a/src/main/java/edu/regis/shatu/dao/StudentModelDAO.java
+++ b/src/main/java/edu/regis/shatu/dao/StudentModelDAO.java
@@ -31,7 +31,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -47,7 +46,11 @@ public class StudentModelDAO extends MySqlDAO implements StudentModelSvc {
     @Override
     public void create(Student student) throws NonRecoverableException {
         final String sql1 = "INSERT INTO StudentModel (UserId, ScaffoldLevel) VALUES (?,?)";
-        final String sql2 = "INSERT INTO Assessment (UserId, KnowledgeComponentId, AssessmentLevel, Exposures, Successes, Hints) VALUES (?,?,?,?,?,?)";
+        final String sql2 = 
+                "INSERT INTO Assessment " +
+                "(UserId, KnowledgeComponentId, AssessmentLevel, Exposures, Successes, Hints) " +
+                "VALUES (?,?,?,?,?,?)";
+        
         String userId = student.getAccount().getUserId();
         StudentModel studentModel = student.getStudentModel();
 
@@ -91,6 +94,7 @@ public class StudentModelDAO extends MySqlDAO implements StudentModelSvc {
     @Override
     public StudentModel retrieve(String userId) throws ObjNotFoundException, NonRecoverableException {
         final String sql = "SELECT ScaffoldLevel FROM StudentModel WHERE UserId = ?";
+        
         Connection conn = null;
         PreparedStatement stmt = null;
         try {
@@ -176,7 +180,7 @@ public class StudentModelDAO extends MySqlDAO implements StudentModelSvc {
         final String sql = """
                     SELECT kc.Title, a.AssessmentLevel
                     FROM Assessment a
-                    JOIN KnowledgeComponent kc ON a.KnowledgeComponentId = kc.Id
+                    JOIN KnowledgeComponent kc ON a.KnowledgeComponentId = kc.KnowledgeComponentId
                     WHERE a.UserId = ?
                 """;
 
@@ -244,11 +248,13 @@ public class StudentModelDAO extends MySqlDAO implements StudentModelSvc {
     //@Override
     public List<String> retrieveAllLessons(String userId) throws NonRecoverableException {
         List<String> lessons = new ArrayList<>();
-        final String sql = "SELECT kc.Title " +
-                           "FROM Assessment a " +
-                           "JOIN KnowledgeComponent kc ON a.KnowledgeComponentId = kc.Id " +
-                           "WHERE a.UserId = ? AND kc.Id NOT IN (0, 10, 20) " +
-                           "ORDER BY kc.Id";
+        final String sql = 
+                "SELECT kc.Title " +
+                "FROM Assessment a " +
+                "JOIN KnowledgeComponent kc ON a.KnowledgeComponentId = kc.KnowledgeComponentId " +
+                "WHERE a.UserId = ? AND kc.KnowledgeComponentId NOT IN (0, 10, 20) " +
+                "ORDER BY kc.KnowledgeComponentId";
+        
         try (Connection conn = DriverManager.getConnection(URL);
              PreparedStatement stmt = conn.prepareStatement(sql)) {
             stmt.setString(1, userId);
@@ -269,12 +275,14 @@ public class StudentModelDAO extends MySqlDAO implements StudentModelSvc {
     @Override
     public AssessmentLevel retrieveAssessmentLevel(String userId, String lesson)
             throws ObjNotFoundException, NonRecoverableException {
-        final String sql = "SELECT a.AssessmentLevel " +
-                           "FROM Assessment a " +
-                           "JOIN KnowledgeComponent kc ON a.KnowledgeComponentId = kc.Id " +
-                           "WHERE a.UserId = ? AND kc.Title = ?";
+        final String sql = 
+                "SELECT a.AssessmentLevel " +
+                "FROM Assessment a " +
+                "JOIN KnowledgeComponent kc ON a.KnowledgeComponentId = kc.KnowledgeComponentId " +
+                "WHERE a.UserId = ? AND kc.Title = ?";
+        
         try (Connection conn = DriverManager.getConnection(URL);
-             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            PreparedStatement stmt = conn.prepareStatement(sql)) {
             stmt.setString(1, userId);
             stmt.setString(2, lesson);
             try (ResultSet rs = stmt.executeQuery()) {
@@ -301,7 +309,9 @@ public class StudentModelDAO extends MySqlDAO implements StudentModelSvc {
     @Override
     public void updateScaffoldLevel(String userId, ScaffoldLevel level)
             throws ObjNotFoundException, NonRecoverableException {
+        
         final String sql = "UPDATE StudentModel SET ScaffoldLevel = ? WHERE UserId = ?";
+        
         try (Connection conn = DriverManager.getConnection(URL);
              PreparedStatement stmt = conn.prepareStatement(sql)) {
              stmt.setString(1, level.toString());
@@ -328,7 +338,9 @@ public class StudentModelDAO extends MySqlDAO implements StudentModelSvc {
     private ArrayList<Assessment> retrieveAssessments(String userId, Connection conn)
             throws ObjNotFoundException, SQLException, NonRecoverableException {
 
-        final String sql = "SELECT Id,KnowledgeComponentId,AssessmentLevel,Exposures,Successes,Hints FROM Assessment WHERE UserId = ?";
+        final String sql =
+                "SELECT AssessmentId, KnowledgeComponentId, AssessmentLevel, Exposures, Successes, Hints " +
+                "FROM Assessment WHERE UserId = ?";
 
         CourseSvc courseSvc = ServiceFactory.findCourseSvc();
         Course course = courseSvc.retrieve(1); // Note only one course possible.

--- a/src/main/java/edu/regis/shatu/svc/ShaTuTutor.java
+++ b/src/main/java/edu/regis/shatu/svc/ShaTuTutor.java
@@ -38,7 +38,6 @@ import edu.regis.shatu.model.aol.AssessmentLevel;
 import edu.regis.shatu.model.aol.NewExampleRequest;
 import edu.regis.shatu.model.aol.PendingStep;
 import edu.regis.shatu.model.aol.PendingTask;
-import edu.regis.shatu.model.aol.Problem;
 import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.aol.StepSubType;
 import edu.regis.shatu.model.aol.StudentModel;
@@ -651,13 +650,7 @@ public class ShaTuTutor implements TutorSvc {
         PendingTask pendingTask = new PendingTask(task);
         pendingTask.setCurrentStep(new PendingStep(task.getCurrentStep()));
         tSession.addTask(pendingTask);
-        
-//        Eventually, this should be the implementation (but task is currently empty)
-//        tSession.setProblem(task.getProblem());
-        // Kludge: Until then, retrieve the problem directly from DB, and manually set it in the session
-        ProblemSvc problemSvc = ServiceFactory.findProblemSvc();
-        Problem problem = problemSvc.retrieve(1);   // 1 = first record in Problem table
-        tSession.setProblem(problem);
+        tSession.setProblem(task.getProblem());
 
         // Generate the security token for this tutoring session.
         Random rnd = new Random();


### PR DESCRIPTION
### Summary
This PR resolves a kludge left in SHAT-321 in which a Problem was manually assigned to a new tutoring session. The logic for assigning Problems to Tasks is now in place and the kludge has been removed. This PR also includes significant improvements to the database schema and related Java code to enhance correctness and maintainability.

### Changes
**Database Script**
- Separated existing foreign key constraints from the create table statements
- Re-arranged to have Create, Insert, and Alter statements sections
    - Similar to how DpTu has it
    - Each section's statements are now in alphabetical order for easier navigation
- Alter statements now handle foreign key constraints
    - Foreign key constraints are based on table column names that implied their need
    - Similar to DpTu
- Renamed primary key columns from 'Id' to '[table name]Id' to avoid ambiguity
- Added ENUM to ExampleType column in Task table
    - This was based on how this field was set for Task objects in retrieveTasks.CourseDAO

**Code**
- Removed kludge in createSession.ShaTuTutor.java to ensure Problems are assigned based on the Task
- Updated retrieveTasks.CourseDAO.java to handle the setting of Problems for each given Task
- Refactored the SQL query string literals in the following DAO classes to reflect the renamed primary keys
    - CourseDAO.java
    - SessionDAO.java
    - StudentModelDAO.java

### Testing
- Deleted and recreated the database to ensure functionality and correctness
- Created a new user successfully
- Reviewed database tables to ensure they were properly populated