### PR TITLE
Fix SEE_ONE mode tutorial flow for new student accounts and entry popup

### DIFF
--- a/src/main/java/edu/regis/shatu/dao/CourseDAO.java
+++ b/src/main/java/edu/regis/shatu/dao/CourseDAO.java
@@ -19,6 +19,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 
+import com.google.gson.Gson;
+
 import edu.regis.shatu.err.InconsistentDBException;
 import edu.regis.shatu.err.NonRecoverableException;
 import edu.regis.shatu.err.ObjNotFoundException;
@@ -38,6 +40,7 @@ import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.aol.StepSubType;
 import edu.regis.shatu.model.aol.TaskKind;
 import edu.regis.shatu.model.aol.Timeout;
+import edu.regis.shatu.model.steps.InformationStep;
 import edu.regis.shatu.model.steps.Step;
 import edu.regis.shatu.svc.CourseSvc;
 
@@ -48,12 +51,19 @@ import edu.regis.shatu.svc.CourseSvc;
  */
 public class CourseDAO extends MySqlDAO implements CourseSvc {
 
+
+    /**
+     * GSON instance for JSON serialization/deserialization.
+     */
+    private static final Gson gson = new Gson();
+
     /**
      * Instantiate this Course DAO with default values.
      */
     public CourseDAO() {
         super("Course", "Id");
     }
+
 
     /**
      * {@inheritDoc}
@@ -213,7 +223,7 @@ public class CourseDAO extends MySqlDAO implements CourseSvc {
     }
 
     /**
-     * Extract child &lt;Outcome> elements from given XML DOM parent element
+     * Extract child &lt; Outcome> elements from given XML DOM parent element
      * adding each as a Outcome to the given Course.
      *
      * @param parent an XML DOM Element containing one or more child
@@ -248,12 +258,17 @@ public class CourseDAO extends MySqlDAO implements CourseSvc {
                 comp.setGranularity(OutcomeGranularity.findValue(rs.getString(8)));
 
                 // Link the exercising locations in this outcome to those in the course.
-                ArrayList<ExercisingLocation> locations = new ArrayList<>();
-                String[] ids = rs.getString(7).split(",");
-                for (int i = 0; i < ids.length; i++)
-                    locations.add(course.findLocation(i));
+                String exLocations = rs.getString(7);
+                if (!exLocations.isEmpty()) {
+                    ArrayList<ExercisingLocation> locations = course.getExercisingLocations();
 
-                comp.setExercisingLocations(locations);
+                    // Find the exercising locations for this outcome
+                    String[] locArray = exLocations.split(",");
+                    for (int i = 0; i < locArray.length; i++) {
+                        int locId = Integer.parseInt(locArray[i]);
+                        comp.addExercisingLocation(locations.get(locId));
+                    }
+                }
 
                 outcomes.add(comp);
             }
@@ -386,19 +401,26 @@ public class CourseDAO extends MySqlDAO implements CourseSvc {
 
             while (rs.next()) {
                 StepSubType subType = StepSubType.findValue(rs.getString(5));
-
+                int subTypeId = rs.getInt(6);
+                
                 Step step = new Step(rs.getInt(1), rs.getInt(4), subType);
-
-                step.setTitle(rs.getString(1));
-                step.setDescription(rs.getString(2));
+                
+                step.setTitle(rs.getString(2));           
+                step.setDescription(rs.getString(3));      
                 step.setTimeout(retrieveTimeout(rs.getInt(7), conn));
-
-                extractStepSubTypeData(subType, rs.getInt(6), conn);
-
-                // ToDo retrieve exercising locations
-
+                
+                String stepData = extractStepSubTypeData(subType, subTypeId, conn);
+                
+                // Convert raw text to JSON for INFO_MESSAGE
+                if (subType == StepSubType.INFO_MESSAGE && stepData != null && !stepData.isEmpty()) {
+                    InformationStep infoStep = new InformationStep();
+                    infoStep.setMsg(stepData);
+                    stepData = gson.toJson(infoStep);
+                    System.out.println("INFO_MESSAGE data: " + stepData);
+                }
+                
+                step.setData(stepData); 
                 steps.add(step);
-
                 step.setHints(retrieveHints(step.getId(), conn));
             }
 

--- a/src/main/java/edu/regis/shatu/svc/ShaTuTutor.java
+++ b/src/main/java/edu/regis/shatu/svc/ShaTuTutor.java
@@ -46,6 +46,7 @@ import edu.regis.shatu.model.aol.TutoringMode;
 import edu.regis.shatu.model.steps.Step;
 import edu.regis.shatu.objectives.*;
 import java.util.Date;
+import edu.regis.shatu.model.steps.EncodeAsciiStep;
 
 /**
  * The ShaTu tutor, which implements the tutoring service.
@@ -379,7 +380,7 @@ public class ShaTuTutor implements TutorSvc {
         }
     }
 
-    /*
+    /* TO-DO: The logic for test sequencing will need to refactor later.
     public TutorReply getTask(String jsonObj) {
         System.out.println("get task method");
 
@@ -510,10 +511,45 @@ public class ShaTuTutor implements TutorSvc {
         }
     }
 
-    public TutorReply completeInfoMsgStep(StepCompletion completion) {
-        TutorReply reply = new TutorReply(":StepCompletionReply");
 
-        return reply;
+    /**
+     * Handles the INFO_MESSAGE step completion
+     * @param completion
+     * @return
+     */
+    public TutorReply completeInfoMsgStep(StepCompletion completion) {
+        TutoringMode mode = session.getTutoringMode();
+        ProblemType firstProblemType;
+        
+        switch (mode) {
+            case SEE_ONE:
+                // First demonstration: ASCII Encoding
+                firstProblemType = ProblemType.ASCII_ENCODE;
+                break;
+            case DO_ONE:
+                // First practice: typically starts with ASCII_ENCODE as well
+                firstProblemType = ProblemType.ASCII_ENCODE;
+                break;
+            case TEACH_ONE:
+                // Teaching mode: starts with ASCII_ENCODE
+                firstProblemType = ProblemType.ASCII_ENCODE;
+                break;
+            default:
+                firstProblemType = ProblemType.ASCII_ENCODE;
+        }
+    
+        // Get the objective for the first task
+        currObjective = getCurrentObjectiveByProbelmType(firstProblemType);
+        
+        // Generate an example for this task
+        // Use the message from the current problem in the session
+        String messageToHash = session.getProblem().getMessageToHash();
+        
+        EncodeAsciiStep encodeStep = new EncodeAsciiStep();
+        encodeStep.setQuestion(messageToHash);
+        String jsonData = gson.toJson(encodeStep);
+
+        return currObjective.example(session, jsonData);
     }
 
     public TutorReply completedTask(String taskInfo) {

--- a/src/main/java/edu/regis/shatu/view/EncodeView.java
+++ b/src/main/java/edu/regis/shatu/view/EncodeView.java
@@ -310,19 +310,6 @@ public class EncodeView extends UserRequestView {
      */
     @Override
     protected void updateView() {
-        // Ensure 'view' is only initialized when SplashFrame.instance() is non-null
-        /*
-        if (view == null) {
-            MainFrame mainFrame = MainFrame.instance();
-            if (mainFrame != null) {
-                view = SplashFrame.instance().getTutoringSessionView(); // Initialize view once SplashFrame is ready
-
-            } else {
-                System.err.println("SplashFrame.instance() is null. Cannot initialize 'view'.");
-                return; // Exit updateView if the view cannot be initialized
-            }
-        }
-*/
         if (this.model == null) { // Currently in development, Encode Ascii starts first when loaded, which model
                                   // can be null initially.
             questionLabel.setText("Please click new example button to get started");
@@ -371,6 +358,16 @@ public class EncodeView extends UserRequestView {
                     } else { // example has been created.
                         questionLabel.setText(String.format("Convert the following "
                                 + "string to binary: %s", question));
+                        
+                        // SEE_ONE MODE: Automatically display the answer for demonstration
+                        if (model != null && model.getTutoringMode() == TutoringMode.SEE_ONE) {
+                            String correctAnswer = newEncodeAscii.getResult();
+                            if (correctAnswer != null && !correctAnswer.isEmpty()) {
+                                responseTextArea.setText(correctAnswer);
+                                feedbackArea.setText("This is the correct binary representation of the message.");
+                            }
+                        }
+                        
                         checkButton.setEnabled(true);
                         responseTextArea.setEnabled(true);
                         hintButton.setEnabled(true);
@@ -395,6 +392,8 @@ public class EncodeView extends UserRequestView {
 
         // Other update logic here
         System.out.println("UpdateView logic continues...");
+        // Ensures that SEE_ONE mode restrictions are enforced even after the updateView logic has enabled fields
+        configureModeSpecificUI();
     }
 
     /**

--- a/src/main/java/edu/regis/shatu/view/TutoringSessionView.java
+++ b/src/main/java/edu/regis/shatu/view/TutoringSessionView.java
@@ -16,15 +16,27 @@ import java.awt.BorderLayout;
 import java.awt.Dimension;
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
 
+import com.google.gson.Gson;  
+import com.google.gson.GsonBuilder;
+
+import edu.regis.shatu.model.Account;
+import edu.regis.shatu.model.StepCompletion;
 import edu.regis.shatu.model.TutoringSession;
 import edu.regis.shatu.model.aol.PendingStep;
 import edu.regis.shatu.model.aol.PendingTask;
+import edu.regis.shatu.model.steps.Step;
+import edu.regis.shatu.svc.ClientRequest;
+import edu.regis.shatu.svc.ServerRequestType;
+import edu.regis.shatu.svc.SvcFacade;
+import edu.regis.shatu.svc.TutorReply;
 import edu.regis.shatu.model.aol.StepSubType;
 import edu.regis.shatu.model.aol.TutoringMode;
+import edu.regis.shatu.model.steps.InformationStep; 
 
 /**
  * Displays a tutoring session.
@@ -77,9 +89,15 @@ public class TutoringSessionView extends GPanel {
     private JButton dashboardButton;
 
     /**
+     * Utility for converstion of java objects to/from JSON.
+     */
+    private Gson gson;
+
+    /**
      * Initialize this view including creating and laying out its child components.
      */
     public TutoringSessionView() {
+        gson = new Gson();
         initializeComponents();
         layoutComponents();  
     }
@@ -100,20 +118,166 @@ public class TutoringSessionView extends GPanel {
      */
     public void setModel(TutoringSession model) {
         this.model = model;
-        
+    
         if (model != null) {
             PendingTask pTask = model.currentTask();
             PendingStep pStep = pTask.getCurrentStep();
             StepSubType subType = pStep.getStep().getSubType();
             
-            displayStep(subType.getViewName());
+            // TEMPORARY DEBUG - Shows dialog with step type -- remove after fixed
+            JOptionPane.showMessageDialog(this, 
+                "DEBUG: Current step type is: " + subType, 
+                "Debug Info", 
+                JOptionPane.INFORMATION_MESSAGE);
+            
+            // Handle INFO_MESSAGE steps with a dialog
+            if (subType == StepSubType.INFO_MESSAGE) {
+                handleInfoMessage(pStep);
+            } else {
+                StepSelection viewName = subType.getViewName();
+                if (viewName != null) {
+                    displayStep(viewName);
+                }
+            }
 
-            stepView.setModel(model);
         }
-        
+        stepView.setModel(model);
         configureModeSpecificUI();
     }
     
+    /**
+     * Handle an information step by displaying its message in a dialog box.
+     * 
+     * @param pStep 
+     */
+    private void handleInfoMessage(PendingStep pStep) {
+        Step step = pStep.getStep();
+        
+        // Check for null step data defensively
+        if (step == null || step.getData() == null) {
+            System.err.println("Warning: INFO_MESSAGE step has null data");
+            return;
+        }
+        
+        try {
+            // Parses JSON data to get the InformationStep
+            InformationStep infoStep = gson.fromJson(step.getData(), InformationStep.class);
+            
+            if (infoStep != null && infoStep.getMsg() != null && !infoStep.getMsg().isEmpty()) {
+                // Show dialog with "Acknowledged" button
+                String[] options = {"Acknowledged"};
+                JOptionPane.showOptionDialog(
+                    this,                           
+                    infoStep.getMsg(),             
+                    "Information",                  
+                    JOptionPane.DEFAULT_OPTION,    
+                    JOptionPane.INFORMATION_MESSAGE, 
+                    null,                          
+                    options,                       
+                    options[0]                     
+                );
+                
+                // Mark the step as complete after acknowledgment
+                completeInfoMessageStep(step,infoStep);
+
+            } else {
+                System.err.println("Warning: INFO_MESSAGE has empty or null message");
+            }
+        } catch (Exception e) {
+            System.err.println("Error parsing INFO_MESSAGE data: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+
+
+    /**
+     * Complete the INFO_MESSAGE step after user acknowledgment.
+     * @param step 
+     * @param infoStep
+     */
+
+     private void completeInfoMessageStep(Step step, InformationStep infoStep) {
+        try {
+            // Creates a StepCompletion object w/current step data
+            StepCompletion completion = new StepCompletion(step, gson.toJson(infoStep));
+            completion.setStep(step);
+            ClientRequest request = new ClientRequest(ServerRequestType.COMPLETED_STEP);
+            Account account = MainFrame.instance().getAccount();
+
+            if (account == null) {
+                System.err.println("Error! No account found when completing INFO_MESSAGE");
+                return;
+            }
+            
+            TutoringSession session = MainFrame.instance().getModel();
+            if (session == null) {
+                System.err.println("Error! No tutoring session found when completing INFO_MESSAGE");
+                return;
+            }
+            
+            request.setUserId(account.getUserId());
+            request.setSecurityToken(session.getSecurityToken());
+            request.setData(gson.toJson(completion));
+            
+            TutorReply reply = SvcFacade.instance().tutorRequest(request);
+            
+
+            if (reply != null) {
+                handleStepCompletionReply(reply);
+            } else {
+                System.err.println("Error: Received null reply from tutor");
+            }
+            
+        } catch (Exception e) {
+            System.err.println("Error completing INFO_MESSAGE step: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+
+    /**
+     * Handle the reply from the server after completing a step.
+     * @param reply from tutorReply from server
+     */
+    private void handleStepCompletionReply(TutorReply reply) {
+        try {
+            switch (reply.getStatus()) {
+                case ":Success":
+                    PendingTask pendingTask = gson.fromJson(reply.getData(), PendingTask.class);
+                    
+                    if (pendingTask != null) {
+                        // Update w/pending task
+                        TutoringSession session = MainFrame.instance().getModel();
+                        session.addCurrentTask(pendingTask);
+                        
+                        setModel(session);
+                    } else {
+                        System.err.println("Error! Received null pending task in reply");
+                    }
+                    break;
+                    
+                case ":ERR":
+                    System.err.println("Error from tutor: " + reply.getData());
+                    JOptionPane.showMessageDialog(
+                        this,
+                        "An error occurred while processing your acknowledgement.",
+                        "Error",
+                        JOptionPane.ERROR_MESSAGE
+                    );
+                    break;
+                    
+                default:
+                    System.err.println("Unexpected reply status: " + reply.getStatus());
+                    break;
+            }
+        } catch (Exception e) {
+            System.err.println("Error handling step completion reply: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+
     /**
      * Display the given selection's view in the StepView handling appropriate
      * highlighting of the associated JLabel selector (see StepSelection enum).
@@ -129,8 +293,6 @@ public class TutoringSessionView extends GPanel {
      * Setup components
      */
     private void initializeComponents() {
-        // StepView must be created before StepSelectorView since the later
-        // references the EncodeView in StepView by selecting it.
         stepView = new StepView();
         stepSelectorView = new StepSelectorView();
 
@@ -149,7 +311,7 @@ public class TutoringSessionView extends GPanel {
     }
 
     /**
-     * New Method to
+     * Configure the UI based on the current tutoring mode.
      */
     private void configureModeSpecificUI() {
         
@@ -195,22 +357,22 @@ public class TutoringSessionView extends GPanel {
         scrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
         scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
 
-        // Set minimum sizes for scrollPane and stepView
-        scrollPane.setMinimumSize(new Dimension(100, 200)); // Minimum size for the scroll pane
-        stepView.setMinimumSize(new Dimension(740, 200));   // Minimum size for the step view
+        
+        scrollPane.setMinimumSize(new Dimension(100, 200)); 
+        stepView.setMinimumSize(new Dimension(740, 200));   
 
         stepViewContainer.add(stepView, BorderLayout.CENTER);
 
-        splitPane.setDividerLocation(259); // Initial width of the left panel in pixels
-        splitPane.setOneTouchExpandable(true); // Allow collapsing and expanding by the user
+        splitPane.setDividerLocation(259); 
+        splitPane.setOneTouchExpandable(true); 
 
-        // Set the layout for this panel
+        
         setLayout(new BorderLayout());
         add(splitPane, BorderLayout.CENTER);
 
-        controlPanel.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 0)); // Adds padding
+        controlPanel.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 0)); 
         controlPanel.add(dashboardButton, BorderLayout.WEST);
-        dashboardButton.setPreferredSize(new Dimension(150, 25)); // Adjustable initial size
+        dashboardButton.setPreferredSize(new Dimension(150, 25)); 
         add(controlPanel, BorderLayout.SOUTH);
     }
 

--- a/src/main/java/edu/regis/shatu/view/act/CreateAcctAction.java
+++ b/src/main/java/edu/regis/shatu/view/act/CreateAcctAction.java
@@ -100,25 +100,14 @@ public class CreateAcctAction extends ShaTuGuiAction {
             case "Created":
                 frame.clearNewAccountPanel();
                 
-                //AutoLogin Transition to tutoring sesh
-                try {
-                    TutoringSession session = gson.fromJson(reply.getData(), TutoringSession.class);
-                    frame.setModel(session);
-                    
-                    msg = "Welcome to ShaTu!\n\n" +
-                          "Your account has been created successfully.\n" +
-                          "Let's begin with 'See One' mode where you'll observe\n" +
-                          "how the SHA-256 algorithm works.";
-                    JOptionPane.showMessageDialog(frame, msg, "Welcome", 
-                                                  JOptionPane.INFORMATION_MESSAGE);
-                } catch (Exception e) {
-                    // If auto-login fails, fall back to manual sign-in
-                    LOGGER.severe("Failed to auto-login after account creation: " + e.getMessage());
-                    msg = "Account created successfully!\n\n" +
-                          "Please sign in to begin.";
-                    JOptionPane.showMessageDialog(frame, msg);
-                    frame.displayView(MainFrame.ViewName.SPLASH);
-                }
+                msg = "Welcome to ShaTu!\n\n" +
+                      "Your account has been created successfully.\n" +
+                      "Please sign in to begin.";
+                JOptionPane.showMessageDialog(frame, msg, "Welcome", 
+                                              JOptionPane.INFORMATION_MESSAGE);
+                
+                // Return to splash/login screen
+                frame.displayView(MainFrame.ViewName.SPLASH);
                 break;
             case "IllegalUserId":
                 msg = "User id already exists: " + account.getUserId();

--- a/src/main/java/edu/regis/shatu/view/act/SignInAction.java
+++ b/src/main/java/edu/regis/shatu/view/act/SignInAction.java
@@ -105,16 +105,11 @@ public class SignInAction extends ShaTuGuiAction {
                 
                 MainFrame frame = MainFrame.instance();
 
+                // Set the model 
                 frame.setModel(session);
                 
                 // Start tracking user inactivity
                 inactivityManager.startTracking();
-                
-                String welcomeMessage = "Welcome, "
-                    + session.getStudent().getAccount().getFirstName()
-                    + "! Your session has successfully started.";
-                JOptionPane.showMessageDialog(null, welcomeMessage, "Welcome", JOptionPane.INFORMATION_MESSAGE);
-
                 
                 break;
                 

--- a/src/main/java/resources/ShaTu.properties
+++ b/src/main/java/resources/ShaTu.properties
@@ -17,11 +17,6 @@ language=en
 country=us
 #country=DE
 
-<<<<<<< HEAD
-edu.regis.shatu.DB_HOST=localhost
-edu.regis.shatu.DB_NAME=ShaTuDB
-edu.regis.shatu.DB_USER=ShaTuTs
-=======
 # The computer host on which the MySQL database executes (default: localhost).
 edu.regis.shatu.DB_HOST=localhost
 
@@ -35,5 +30,4 @@ edu.regis.shatu.DB_NAME=ShaTuDB
 edu.regis.shatu.DB_USER=ShaTuTs
 
 # The password ShaTu uses to login to the database (default: ShTu2023).
->>>>>>> e729936a04f120488f7da9a1bd02ddd370b85ec3
 edu.regis.shatu.DB_PASS=ShaTu2023


### PR DESCRIPTION

1. Implemented INFO_MESSAGE Step Handling (TutoringSessionView.java)
   - Added dialog display for INFO_MESSAGE steps with "Acknowledged" button
   - Implemented step completion flow to request next task from server
   - Initialized Gson instance (was declared but never instantiated, causing NPEs)

2. Fixed Server-Side Step Progression (ShaTuTutor.java)
   - Implemented completeInfoMsgStep() stub method to properly return next task
   - Changed response status from :StepCompletionReply to: Success with valid PendingTask
   - Fixed JSON format issues by wrapping messages in proper EncodeAsciiStep objects

3. Fixed SEE_ONE Mode UI Behavior (EncodeView.java)
   - Added mode-specific UI configuration to disable interactive elements in SEE_ONE mode
   - Called configureModeSpecificUI() after view updates to maintain restrictions
   - Ensured students can only observe demonstrations, not interact

4. Cleaned Up Account Creation Flow
   - Simplified account creation messages (CreateAcctAction.java)
   - Removed conflicting welcome dialogs (SignInAction.java)

**New students now successfully see the welcome message, acknowledge it, and progress 
to their first ASCII encoding demonstration with proper SEE_ONE mode restrictions 
enforced.
