### PR TITLE
Shat-335

### DIFF
--- a/src/main/java/edu/regis/shatu/model/aol/StepSubType.java
+++ b/src/main/java/edu/regis/shatu/model/aol/StepSubType.java
@@ -126,6 +126,15 @@ public enum StepSubType {
     public StepSelection getViewName() {
         return viewName;
     }
+
+    /**
+     * Return a user facing name for the subtype while returning label.
+     *
+     * @return display text suitable for UI or logging
+     */
+    public String getDisplayName() {
+        return (viewName != null) ? viewName.getLabel().getText() : subType;
+    }
     
     /**
      * Return the subType name that is used by the server


### PR DESCRIPTION
Added StepSubType.getDisplayName() so any UI/log code referencing the subtype can reuse the StepSelection label text instead of a hard-coded string, reducing the risk of future drift