### PR TITLE
Shat 161

### DIFF
--- a/setup_ShaTuDB.sql
+++ b/setup_ShaTuDB.sql
@@ -39,7 +39,8 @@ CREATE TABLE Assessment (
     AssessmentLevel VARCHAR(32) NOT NULL,
     Exposures INT,
     Successes INT,
-    Hints INT
+    Hints INT,
+    CorrectAnswerRequests INT
 );
 
 -- Truncate Table Assessment;
@@ -493,4 +494,3 @@ ALTER Table Unit
 ADD CONSTRAINT fk_unit_courseid
 FOREIGN KEY (CourseId) REFERENCES Course(CourseId)
 ON UPDATE CASCADE ON DELETE CASCADE;
-

--- a/src/main/java/edu/regis/shatu/dao/StudentModelDAO.java
+++ b/src/main/java/edu/regis/shatu/dao/StudentModelDAO.java
@@ -49,12 +49,15 @@ public class StudentModelDAO extends MySqlDAO implements StudentModelSvc {
         final String sql2 = 
                 "INSERT INTO Assessment " +
 <<<<<<< Updated upstream
+<<<<<<< Updated upstream
                 "(UserId, KnowledgeComponentId, AssessmentLevel, Exposures, Successes, Hints) " +
                 "VALUES (?,?,?,?,?,?)";
         
         String userId = student.getAccount().getUserId();
         StudentModel studentModel = student.getStudentModel();
 =======
+=======
+>>>>>>> Stashed changes
                 "(UserId, KnowledgeComponentId, AssessmentLevel, Exposures, Successes, Hints, CorrectAnswerRequests) " +
                 "VALUES (?,?,?,?,?,?,?)";
         final String sql3 = 

--- a/src/main/java/edu/regis/shatu/dao/StudentModelDAO.java
+++ b/src/main/java/edu/regis/shatu/dao/StudentModelDAO.java
@@ -48,11 +48,46 @@ public class StudentModelDAO extends MySqlDAO implements StudentModelSvc {
         final String sql1 = "INSERT INTO StudentModel (UserId, ScaffoldLevel) VALUES (?,?)";
         final String sql2 = 
                 "INSERT INTO Assessment " +
+<<<<<<< Updated upstream
                 "(UserId, KnowledgeComponentId, AssessmentLevel, Exposures, Successes, Hints) " +
                 "VALUES (?,?,?,?,?,?)";
         
         String userId = student.getAccount().getUserId();
         StudentModel studentModel = student.getStudentModel();
+=======
+                "(UserId, KnowledgeComponentId, AssessmentLevel, Exposures, Successes, Hints, CorrectAnswerRequests) " +
+                "VALUES (?,?,?,?,?,?,?)";
+        final String sql3 = 
+                "INSERT INTO Student " + 
+                "(UserId, FirstName, LastName, LastLogin, LastLogout) " +
+                "VALUES (?, ?, ?, ?, ?)";
+        
+        String userId = student.getAccount().getUserId();
+        StudentModel studentModel = student.getStudentModel();
+        
+        try(Connection conn = DriverManager.getConnection(URL)){
+            conn.setAutoCommit(false);    // Only commit if all insertions succeed
+            
+            try(PreparedStatement stmt1 = conn.prepareStatement(sql1);
+                PreparedStatement stmt2 = conn.prepareStatement(sql2, Statement.RETURN_GENERATED_KEYS);
+                PreparedStatement stmt3 = conn.prepareStatement(sql3);
+                ){
+                // Insert into StudentModel
+                stmt1.setString(1, userId);
+                stmt1.setString(2, ScaffoldLevel.EXTREME.toString());
+                stmt1.executeUpdate();
+                
+                // Insert into Assessment
+                for (Assessment assessment : studentModel.getAssessments().values()) {
+                    stmt2.setString(1, userId);
+                    stmt2.setInt(2, assessment.getOutcome().getId());
+                    stmt2.setString(3, "Not Started");
+                    stmt2.setInt(4, assessment.getExposures());
+                    stmt2.setInt(5, assessment.getSuccessess());
+                    stmt2.setInt(6, assessment.getHints());
+                    stmt2.setInt(7, assessment.getCorrectAnswerRequests());
+                    stmt2.executeUpdate();
+>>>>>>> Stashed changes
 
         Connection conn = null;
         PreparedStatement stmt1 = null;
@@ -152,6 +187,11 @@ public class StudentModelDAO extends MySqlDAO implements StudentModelSvc {
                     sql = "UPDATE Assessment SET Hints = ? WHERE KnowledgeComponentId = ?";
                     stmt = conn.prepareStatement(sql);
                     stmt.setInt(1, assessment.getHints());
+                    break;
+                case CORRECT_ANSWER_REQUESTS:
+                    sql = "UPDATE Assessment SET CorrectAnswerRequests = ? WHERE KnowledgeComponentId = ?";
+                    stmt = conn.prepareStatement(sql);
+                    stmt.setInt(1, assessment.getCorrectAnswerRequests());
                     break;
                 default:
                     break;
@@ -339,7 +379,7 @@ public class StudentModelDAO extends MySqlDAO implements StudentModelSvc {
             throws ObjNotFoundException, SQLException, NonRecoverableException {
 
         final String sql =
-                "SELECT AssessmentId, KnowledgeComponentId, AssessmentLevel, Exposures, Successes, Hints " +
+                "SELECT AssessmentId, KnowledgeComponentId, AssessmentLevel, Exposures, Successes, Hints, CorrectAnswerRequests " +
                 "FROM Assessment WHERE UserId = ?";
 
         CourseSvc courseSvc = ServiceFactory.findCourseSvc();
@@ -359,6 +399,7 @@ public class StudentModelDAO extends MySqlDAO implements StudentModelSvc {
             assessment.setExposures(rs.getInt(4));
             assessment.setSuccessess(rs.getInt(5));
             assessment.setHints(rs.getInt(6));
+            assessment.setCorrectAnswerRequests(rs.getInt(7));
             assessments.add(assessment);
         }
         return assessments;

--- a/src/main/java/edu/regis/shatu/model/StudentModelFieldKind.java
+++ b/src/main/java/edu/regis/shatu/model/StudentModelFieldKind.java
@@ -28,6 +28,8 @@ public enum StudentModelFieldKind {
     SUCCESSES("Success"),
     
     HINTS("Hints"),
+
+    CORRECT_ANSWER_REQUESTS("Correct Answer Requests"),
     
     ALL("All");
     

--- a/src/main/java/edu/regis/shatu/model/aol/Assessment.java
+++ b/src/main/java/edu/regis/shatu/model/aol/Assessment.java
@@ -51,6 +51,11 @@ public class Assessment extends Model {
      * component in this assessment.
      */
     private int hints;
+
+    /**
+     * The number of times the student requested to see the correct answer after answering incorrectly.
+     */
+    private int correctAnswerRequests;
     
     public Assessment(KnowledgeComponent outcome, AssessmentLevel assessment) {
         this.outcome = outcome;
@@ -122,5 +127,17 @@ public class Assessment extends Model {
     public void incrementHints() {
         hints++;
         System.out.println("Hints incremented to " + hints);
+    }
+
+    public int getCorrectAnswerRequests() {
+        return correctAnswerRequests;
+    }
+
+    public void setCorrectAnswerRequests(int correctAnswerRequests) {
+        this.correctAnswerRequests = correctAnswerRequests;
+    }
+
+    public void incrementCorrectAnswerRequests() {
+        correctAnswerRequests++;
     }
 }

--- a/src/main/java/edu/regis/shatu/model/aol/CorrectAnswerRequest.java
+++ b/src/main/java/edu/regis/shatu/model/aol/CorrectAnswerRequest.java
@@ -1,0 +1,38 @@
+/*
+ * SHATU: SHA-256 Tutor
+ *
+ *  (C) Johanna & Richard Blumenthal, All rights reserved
+ *
+ *  Unauthorized use, duplication or distribution without the authors'
+ *  permission is strictly prohibited.
+ *
+ *  Unless required by applicable law or agreed to in writing, this
+ *  software is distributed on an "AS IS" basis without warranties
+ *  or conditions of any kind, either expressed or implied.
+ */
+package edu.regis.shatu.model.aol;
+
+/**
+ * Encapsulates a request to record that the student asked to see the correct answer.
+ */
+public class CorrectAnswerRequest {
+    /**
+     * The knowledge component identifier associated with the completed step.
+     */
+    private int knowledgeComponentId;
+
+    public CorrectAnswerRequest() {
+    }
+
+    public CorrectAnswerRequest(int knowledgeComponentId) {
+        this.knowledgeComponentId = knowledgeComponentId;
+    }
+
+    public int getKnowledgeComponentId() {
+        return knowledgeComponentId;
+    }
+
+    public void setKnowledgeComponentId(int knowledgeComponentId) {
+        this.knowledgeComponentId = knowledgeComponentId;
+    }
+}

--- a/src/main/java/edu/regis/shatu/objectives/InitVars.java
+++ b/src/main/java/edu/regis/shatu/objectives/InitVars.java
@@ -197,6 +197,7 @@ public class InitVars extends Objective {
         stepReply.setIsRepeatStep(!allCorrect);
         stepReply.setIsNewStep(allCorrect);
         stepReply.setIsNextStep(false);
+        stepReply.addExercisedComponentId(dbId);
 
         // Wrap the StepCompletionReply into a Task and TutorReply
         Step step = new Step(1, 0, StepSubType.STEP_COMPLETION_REPLY);

--- a/src/main/java/edu/regis/shatu/objectives/Objective.java
+++ b/src/main/java/edu/regis/shatu/objectives/Objective.java
@@ -255,6 +255,8 @@ abstract public class Objective {
 
         step.setData(gson.toJson(subStep));
 
+        stepReply.addExercisedComponentId(stepName.dbId());
+
         Task task = new Task();
         task.setKind(TaskKind.PROBLEM);
         task.setType(probType);

--- a/src/main/java/edu/regis/shatu/svc/ServerRequestType.java
+++ b/src/main/java/edu/regis/shatu/svc/ServerRequestType.java
@@ -86,7 +86,12 @@ public enum ServerRequestType {
     /**
      * Get the current task of the user
      */
-    GET_TASK(":GetTask");
+    GET_TASK(":GetTask"),
+
+    /**
+     * Record that the student asked to reveal the correct answer.
+     */
+    RECORD_CORRECT_ANSWER(":RecordCorrectAnswer");
 
     /**
      * The name used by the server to identify this request.

--- a/src/main/java/edu/regis/shatu/svc/ShaTuTutor.java
+++ b/src/main/java/edu/regis/shatu/svc/ShaTuTutor.java
@@ -30,11 +30,13 @@ import edu.regis.shatu.model.Course;
 import edu.regis.shatu.model.KnowledgeComponent;
 import edu.regis.shatu.model.StepCompletion;
 import edu.regis.shatu.model.Student;
+import edu.regis.shatu.model.StudentModelFieldKind;
 import edu.regis.shatu.model.Task;
 import edu.regis.shatu.model.TutoringSession;
 import edu.regis.shatu.model.Unit;
 import edu.regis.shatu.model.aol.Assessment;
 import edu.regis.shatu.model.aol.AssessmentLevel;
+import edu.regis.shatu.model.aol.CorrectAnswerRequest;
 import edu.regis.shatu.model.aol.NewExampleRequest;
 import edu.regis.shatu.model.aol.PendingStep;
 import edu.regis.shatu.model.aol.PendingTask;
@@ -124,6 +126,7 @@ public class ShaTuTutor implements TutorSvc {
             case "newExample":
             case "requestHint":
             case "resetPassword":
+            case "recordCorrectAnswer":
                 String userId = request.getUserId();
                 try {
                     if (verifySession(userId, request.getSecurityToken())) {
@@ -378,6 +381,70 @@ public class ShaTuTutor implements TutorSvc {
             return new TutorReply();
         }
     }
+<<<<<<< Updated upstream
+=======
+
+    /**
+     * Records that the student asked to see the correct answer for the given knowledge component.
+     *
+     * @param jsonData a JSon encoded {@link CorrectAnswerRequest}
+     * @return a TutorReply indicating success or failure.
+     */
+    public TutorReply recordCorrectAnswer(String jsonData) {
+        CorrectAnswerRequest request = gson.fromJson(jsonData, CorrectAnswerRequest.class);
+        int knowledgeComponentId = request.getKnowledgeComponentId();
+
+        if (knowledgeComponentId <= 0) {
+            return createError("Invalid knowledge component id for correct answer request", null);
+        }
+
+        Assessment assessment = studentModel.findAssessment(knowledgeComponentId);
+        if (assessment == null) {
+            return createError("Assessment not found for knowledge component: " + knowledgeComponentId, null);
+        }
+
+        assessment.incrementCorrectAnswerRequests();
+
+        try {
+            StudentModelSvc modelSvc = ServiceFactory.findStudentModelSvc();
+            modelSvc.updateAssessment(studentModel, assessment, StudentModelFieldKind.CORRECT_ANSWER_REQUESTS);
+            return new TutorReply(":Success");
+        } catch (NonRecoverableException ex) {
+            return createError("Unable to update correct answer requests", ex);
+        }
+    }
+    
+    /**
+     * Attempts to sign a student out.
+     * 
+     * This method handles ":SignOut" requests from the GUI client.
+     * 
+     * It is invoked indirectly as a reflection from within request().
+     *
+     * @param jsonUser a JSON encoded User object
+     * @return a TutorReply indicating "SIGN_OUT" for success or ":ERR" for failure
+     */
+    public TutorReply signOut(String jsonUser) {
+        Account requestAcct = gson.fromJson(jsonUser, Account.class);
+
+        try {
+            student = new Student(requestAcct);
+            notifyLogout(student);
+            return new TutorReply("SIGN_OUT");
+        }
+        catch (ObjNotFoundException ex) {
+            TutorReply reply = new TutorReply(":ERR");
+            reply.setData("Student model not found for: " + requestAcct.getUserId());
+            return reply;
+        }
+        catch (NonRecoverableException ex) {
+            Logger.getLogger(ShaTuTutor.class.getName()).log(Level.SEVERE, null, ex);
+            TutorReply reply = new TutorReply(":ERR");
+            reply.setData("NonRecoverableException occured during sign-out");
+            return reply;
+        }
+    }
+>>>>>>> Stashed changes
 
     /*
     public TutorReply getTask(String jsonObj) {
@@ -873,5 +940,3 @@ public class ShaTuTutor implements TutorSvc {
        // LOGGER.log(Level.INFO, "Student {0} logged out at {1}", new Object[]{student.getAccount().getUserId(), milliseconds});
     }
 }
-
-

--- a/src/main/java/edu/regis/shatu/svc/ShaTuTutor.java
+++ b/src/main/java/edu/regis/shatu/svc/ShaTuTutor.java
@@ -382,7 +382,10 @@ public class ShaTuTutor implements TutorSvc {
         }
     }
 <<<<<<< Updated upstream
+<<<<<<< Updated upstream
 =======
+=======
+>>>>>>> Stashed changes
 
     /**
      * Records that the student asked to see the correct answer for the given knowledge component.

--- a/src/main/java/edu/regis/shatu/view/act/StepCompletionAction.java
+++ b/src/main/java/edu/regis/shatu/view/act/StepCompletionAction.java
@@ -19,17 +19,18 @@ package edu.regis.shatu.view.act;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
+import java.util.List;
 import java.util.logging.Logger;
 
 import javax.swing.JOptionPane;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 
 import edu.regis.shatu.err.IllegalArgException;
 import edu.regis.shatu.model.Account;
 import edu.regis.shatu.model.StepCompletion;
 import edu.regis.shatu.model.Task;
+import edu.regis.shatu.model.aol.CorrectAnswerRequest;
 import edu.regis.shatu.model.aol.PendingTask;
 import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.aol.StepSubType;
@@ -257,6 +258,7 @@ public class StepCompletionAction extends ShaTuGuiAction {
                                     }
                                     case 2 -> {
                                         System.out.println("show answer");
+                                        recordCorrectAnswerRequest(stepReply, gson);
                                         JOptionPane.showMessageDialog(MainFrame.instance(),
                                                 stepReply.getCorrectAnswer(), "Tutor Reply",
                                                 JOptionPane.INFORMATION_MESSAGE);
@@ -275,5 +277,31 @@ public class StepCompletionAction extends ShaTuGuiAction {
         } catch (IllegalArgException e) {
             System.out.println("Illegal arg exception " + e);
         }
+    }
+
+    /**
+     * Inform the tutor that the student asked to see the correct answer so we can track the request.
+     *
+     * @param stepReply reply data containing the knowledge component id involved in the previous attempt
+     * @param gson      serializer used to encode the request payload
+     */
+    private void recordCorrectAnswerRequest(StepCompletionReply stepReply, Gson gson) {
+        List<Integer> componentIds = stepReply.getExercisedComponentIds();
+        if (componentIds == null || componentIds.isEmpty()) {
+            return;
+        }
+
+        int knowledgeComponentId = componentIds.get(0);
+        if (knowledgeComponentId <= 0) {
+            return;
+        }
+
+        CorrectAnswerRequest payload = new CorrectAnswerRequest(knowledgeComponentId);
+        ClientRequest request = new ClientRequest(ServerRequestType.RECORD_CORRECT_ANSWER);
+        Account account = MainFrame.instance().getAccount();
+        request.setUserId(account.getUserId());
+        request.setSecurityToken(MainFrame.instance().getModel().getSecurityToken());
+        request.setData(gson.toJson(payload));
+        SvcFacade.instance().tutorRequest(request);
     }
 }


### PR DESCRIPTION
* First added a CorrectAnswerRequests column to the Assessment list and added the field through the domain model/DAO so each outcome now tracks how many reveal events happened. 
* the Swing controller maps the “Show the Correct Answer” choice to that id when it needs to log a reveal.
* Added CorrectAnswerRequest and a  :RecordCorrectAnswer tutor request. (client uses it whenever the reveal button is used)
* The tutor validates the session, increments the new counter, and sends it through.
