### PR TITLE
SHAT-161

### DIFF
--- a/setup_ShaTuDB.sql
+++ b/setup_ShaTuDB.sql
@@ -39,7 +39,8 @@ CREATE TABLE Assessment (
     AssessmentLevel VARCHAR(32) NOT NULL,
     Exposures INT,
     Successes INT,
-    Hints INT
+    Hints INT,
+    CorrectAnswersRequested INT DEFAULT 0
 );
 
 -- Truncate Table Assessment;

--- a/src/main/java/edu/regis/shatu/dao/StudentModelDAO.java
+++ b/src/main/java/edu/regis/shatu/dao/StudentModelDAO.java
@@ -50,8 +50,8 @@ public class StudentModelDAO extends MySqlDAO implements StudentModelSvc {
         final String sql1 = "INSERT INTO StudentModel (UserId, ScaffoldLevel) VALUES (?,?)";
         final String sql2 = 
                 "INSERT INTO Assessment " +
-                "(UserId, KnowledgeComponentId, AssessmentLevel, Exposures, Successes, Hints) " +
-                "VALUES (?,?,?,?,?,?)";
+                "(UserId, KnowledgeComponentId, AssessmentLevel, Exposures, Successes, Hints, CorrectAnswersRequested) " +
+                "VALUES (?,?,?,?,?,?,?)";
         final String sql3 = 
                 "INSERT INTO Student " + 
                 "(UserId, FirstName, LastName, LastLogin, LastLogout) " +
@@ -80,6 +80,7 @@ public class StudentModelDAO extends MySqlDAO implements StudentModelSvc {
                     stmt2.setInt(4, assessment.getExposures());
                     stmt2.setInt(5, assessment.getSuccessess());
                     stmt2.setInt(6, assessment.getHints());
+                    stmt2.setInt(7, assessment.getCorrectAnswersRequested());
                     stmt2.executeUpdate();
 
                     ResultSet rs = stmt2.getGeneratedKeys();
@@ -172,6 +173,11 @@ public class StudentModelDAO extends MySqlDAO implements StudentModelSvc {
                     sql = "UPDATE Assessment SET Hints = ? WHERE KnowledgeComponentId = ?";
                     stmt = conn.prepareStatement(sql);
                     stmt.setInt(1, assessment.getHints());
+                    break;
+                case CORRECT_ANSWERS_REQUESTED:
+                    sql = "UPDATE Assessment SET CorrectAnswersRequested = ? WHERE KnowledgeComponentId = ?";
+                    stmt = conn.prepareStatement(sql);
+                    stmt.setInt(1, assessment.getCorrectAnswersRequested());
                     break;
                 default:
                     break;
@@ -359,7 +365,7 @@ public class StudentModelDAO extends MySqlDAO implements StudentModelSvc {
             throws ObjNotFoundException, SQLException, NonRecoverableException {
 
         final String sql =
-                "SELECT AssessmentId, KnowledgeComponentId, AssessmentLevel, Exposures, Successes, Hints " +
+                "SELECT AssessmentId, KnowledgeComponentId, AssessmentLevel, Exposures, Successes, Hints, CorrectAnswersRequested " +
                 "FROM Assessment WHERE UserId = ?";
 
         CourseSvc courseSvc = ServiceFactory.findCourseSvc();
@@ -379,6 +385,7 @@ public class StudentModelDAO extends MySqlDAO implements StudentModelSvc {
             assessment.setExposures(rs.getInt(4));
             assessment.setSuccessess(rs.getInt(5));
             assessment.setHints(rs.getInt(6));
+            assessment.setCorrectAnswersRequested(rs.getInt(7));
             assessments.add(assessment);
         }
         return assessments;

--- a/src/main/java/edu/regis/shatu/model/StudentModelFieldKind.java
+++ b/src/main/java/edu/regis/shatu/model/StudentModelFieldKind.java
@@ -28,6 +28,8 @@ public enum StudentModelFieldKind {
     SUCCESSES("Success"),
     
     HINTS("Hints"),
+
+    CORRECT_ANSWERS_REQUESTED("Correct Answers Requested"),
     
     ALL("All");
     

--- a/src/main/java/edu/regis/shatu/model/aol/Assessment.java
+++ b/src/main/java/edu/regis/shatu/model/aol/Assessment.java
@@ -51,6 +51,12 @@ public class Assessment extends Model {
      * component in this assessment.
      */
     private int hints;
+
+    /**
+     * The number of times the student requested to see the correct answer after
+     * submitting an incorrect response.
+     */
+    private int correctAnswersRequested;
     
     public Assessment(KnowledgeComponent outcome, AssessmentLevel assessment) {
         this.outcome = outcome;
@@ -122,5 +128,20 @@ public class Assessment extends Model {
     public void incrementHints() {
         hints++;
         System.out.println("Hints incremented to " + hints);
+    }
+
+    public int getCorrectAnswersRequested() {
+        return correctAnswersRequested;
+    }
+
+    public void setCorrectAnswersRequested(int correctAnswersRequested) {
+        this.correctAnswersRequested = correctAnswersRequested;
+    }
+
+    /**
+     * Increment the number of requested correct answers.
+     */
+    public void incrementCorrectAnswersRequested() {
+        correctAnswersRequested++;
     }
 }

--- a/src/main/java/edu/regis/shatu/svc/ServerRequestType.java
+++ b/src/main/java/edu/regis/shatu/svc/ServerRequestType.java
@@ -77,6 +77,11 @@ public enum ServerRequestType {
      * "ERR" data is error message
      */
     REQUEST_HINT(":RequestHint"),
+
+    /**
+     * The student requested to see the correct answer after an incorrect attempt.
+     */
+    REQUEST_CORRECT_ANSWER(":RequestCorrectAnswer"),
     
     /**
      * The student has reset their password.

--- a/src/main/java/edu/regis/shatu/svc/ShaTuServer.java
+++ b/src/main/java/edu/regis/shatu/svc/ShaTuServer.java
@@ -28,7 +28,7 @@ import com.google.gson.Gson;
  *
  * Protocol msg ::= &lt;cmd> &lt;argData> <br>
  * &lt;cmd> ::= :CreateStudentAccount | :LaunchSession | :SignIn | <br>
- * :RequestHint | :CompletedStep | :CompletedTask <br>
+ * :RequestHint | :RequestCorrectAnswer | :CompletedStep | :CompletedTask <br>
  * The &lt;argData> for each command is documented in the TutorSvc interface.
  *
  * @author Rickb

--- a/src/main/java/edu/regis/shatu/svc/ShaTuTutor.java
+++ b/src/main/java/edu/regis/shatu/svc/ShaTuTutor.java
@@ -29,11 +29,13 @@ import edu.regis.shatu.err.ObjNotFoundException;
 import edu.regis.shatu.model.Account;
 import edu.regis.shatu.model.Course;
 import edu.regis.shatu.model.KnowledgeComponent;
+import edu.regis.shatu.model.KnowledgeComponentKind;
 import edu.regis.shatu.model.StepCompletion;
 import edu.regis.shatu.model.Student;
 import edu.regis.shatu.model.Task;
 import edu.regis.shatu.model.TutoringSession;
 import edu.regis.shatu.model.Unit;
+import edu.regis.shatu.model.StudentModelFieldKind;
 import edu.regis.shatu.model.aol.Assessment;
 import edu.regis.shatu.model.aol.AssessmentLevel;
 import edu.regis.shatu.model.aol.NewExampleRequest;
@@ -123,6 +125,7 @@ public class ShaTuTutor implements TutorSvc {
             //case "getTask":
             case "newExample":
             case "requestHint":
+            case "requestCorrectAnswer":
             case "resetPassword":
                 String userId = request.getUserId();
                 try {
@@ -519,6 +522,47 @@ public class ShaTuTutor implements TutorSvc {
     }
 
     /**
+     * Records that the student asked to see the correct answer after an
+     * incorrect attempt.
+     *
+     * This method handles ":RequestCorrectAnswer" requests from the GUI client.
+     *
+     * @param jsonObj a JSon encoded StepCompletion object
+     * @return a TutorReply with status ":Success" or ":ERR"
+     */
+    public TutorReply requestCorrectAnswer(String jsonObj) {
+        StepCompletion completion = gson.fromJson(jsonObj, StepCompletion.class);
+
+        if (completion == null || completion.getStep() == null) {
+            return createError("Missing step information for correct answer request", null);
+        }
+
+        ProblemType problemType = convertStepToProblemType(completion.getStep().getSubType());
+        KnowledgeComponentKind knowledgeComponentKind = mapProblemTypeToKnowledgeComponent(problemType);
+
+        if (knowledgeComponentKind == null) {
+            return createError("Unknown problem type for correct answer request: " + problemType, null);
+        }
+
+        Assessment assessment = studentModel.findAssessment(knowledgeComponentKind.dbId());
+
+        if (assessment == null) {
+            return createError("Assessment not found for: " + knowledgeComponentKind.title(), null);
+        }
+
+        assessment.incrementCorrectAnswersRequested();
+
+        try {
+            StudentModelSvc modelSvc = ServiceFactory.findStudentModelSvc();
+            modelSvc.updateAssessment(studentModel, assessment, StudentModelFieldKind.CORRECT_ANSWERS_REQUESTED);
+        } catch (NonRecoverableException ex) {
+            return createError("Unknown error updating correct answer request count", ex);
+        }
+
+        return new TutorReply(":Success");
+    }
+
+    /**
      * @param jsonObj a JSon encoded StepCompletion object
      * @return
      */
@@ -704,6 +748,53 @@ public class ShaTuTutor implements TutorSvc {
                 return ProblemType.SHA_ONE;
             default:
                 System.out.println("Unknown step type in convert: " + stepType);
+                return null;
+        }
+    }
+
+    /**
+     * Map a problem type to the associated knowledge component.
+     *
+     * @param problemType the problem type for which the student asked to see the answer
+     * @return the matching KnowledgeComponentKind or null if none exists
+     */
+    private KnowledgeComponentKind mapProblemTypeToKnowledgeComponent(ProblemType problemType) {
+        if (problemType == null) {
+            return null;
+        }
+
+        switch (problemType) {
+            case ASCII_ENCODE:
+                return KnowledgeComponentKind.ASCII_ENCODE;
+            case ADD_ONE_BIT:
+                return KnowledgeComponentKind.ADD_ONE_BIT;
+            case PAD_ZEROS:
+                return KnowledgeComponentKind.PAD_ZEROS;
+            case ADD_MSG_LENGTH:
+                return KnowledgeComponentKind.ADD_MSG_LENGTH;
+            case PREPARE_SCHEDULE:
+                return KnowledgeComponentKind.PREPARE_SCHEDULE;
+            case INITIALIZE_VARS:
+                return KnowledgeComponentKind.INITIALIZE_VARS;
+            case COMPRESS_ROUND:
+                return KnowledgeComponentKind.COMPRESS_ROUND;
+            case ROTATE_BITS:
+                return KnowledgeComponentKind.ROTATE_BITS;
+            case SHIFT_BITS:
+                return KnowledgeComponentKind.SHIFT_BITS;
+            case XOR_BITS:
+                return KnowledgeComponentKind.XOR_BITS;
+            case ADD_BITS:
+                return KnowledgeComponentKind.ADD_BITS;
+            case MAJORITY_FUNCTION:
+                return KnowledgeComponentKind.MAJORITY_FUNCTION;
+            case CHOICE_FUNCTION:
+                return KnowledgeComponentKind.CHOICE_FUNCTION;
+            case SHA_ZERO:
+                return KnowledgeComponentKind.SHA_ZERO;
+            case SHA_ONE:
+                return KnowledgeComponentKind.SHA_ONE;
+            default:
                 return null;
         }
     }

--- a/src/main/java/edu/regis/shatu/view/act/StepCompletionAction.java
+++ b/src/main/java/edu/regis/shatu/view/act/StepCompletionAction.java
@@ -19,6 +19,7 @@ package edu.regis.shatu.view.act;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.swing.JOptionPane;
@@ -257,6 +258,7 @@ public class StepCompletionAction extends ShaTuGuiAction {
                                     }
                                     case 2 -> {
                                         System.out.println("show answer");
+                                        recordCorrectAnswerRequest(gson, account, ex);
                                         JOptionPane.showMessageDialog(MainFrame.instance(),
                                                 stepReply.getCorrectAnswer(), "Tutor Reply",
                                                 JOptionPane.INFORMATION_MESSAGE);
@@ -274,6 +276,27 @@ public class StepCompletionAction extends ShaTuGuiAction {
             }
         } catch (IllegalArgException e) {
             System.out.println("Illegal arg exception " + e);
+        }
+    }
+
+    /**
+     * Notify the tutor that the student requested to see the correct answer so the
+     * event can be persisted.
+     */
+    private void recordCorrectAnswerRequest(Gson gson, Account account, StepCompletion completion) {
+        try {
+            ClientRequest correctAnswerRequest = new ClientRequest(ServerRequestType.REQUEST_CORRECT_ANSWER);
+            correctAnswerRequest.setUserId(account.getUserId());
+            correctAnswerRequest.setSecurityToken(MainFrame.instance().getModel().getSecurityToken());
+            correctAnswerRequest.setData(gson.toJson(completion));
+
+            TutorReply recordReply = SvcFacade.instance().tutorRequest(correctAnswerRequest);
+
+            if (!":Success".equals(recordReply.getStatus())) {
+                LOGGER.warning("Failed to record correct answer request: " + recordReply.getStatus());
+            }
+        } catch (Exception ex) {
+            LOGGER.log(Level.WARNING, "Unable to record correct answer request", ex);
         }
     }
 }


### PR DESCRIPTION
* Added assessment tracking for requested correct answers and wired it
* Introduced a tutor request to log when a student clicks “Show the correct Answer,” with server handling that maps the step subtype back to its knowledge component and updates the student model
* Hooked the UI flow so the client notifies the tutor whenever that button is chosen before showing the answer

* I fixed the mess which was my old PR and redid it.