### PR TITLE
added actionlistener to reduce sign-in keystrokes

### DIFF
--- a/src/main/java/edu/regis/shatu/view/SplashPanel.java
+++ b/src/main/java/edu/regis/shatu/view/SplashPanel.java
@@ -198,6 +198,8 @@ public class SplashPanel extends GPanel {
 
 	signInBut = new JButton(SignInAction.instance());
 	signInBut.setEnabled(false);
+        
+        password.addActionListener(e -> signInBut.doClick());
         /*
         signInBut.addActionListener(e -> {
         // Fetch the userId and encrypted password


### PR DESCRIPTION
added actionlistener to the splash screen to allow users to hit the sign-in button by pressing enter when the password field is active