### PR TITLE
SHAT-355 New Example Encode Ascii Working

### DIFF
--- a/src/main/java/edu/regis/shatu/model/TutoringSession.java
+++ b/src/main/java/edu/regis/shatu/model/TutoringSession.java
@@ -146,11 +146,18 @@ public class TutoringSession {
 
     
     public TutoringMode getTutoringMode() {
-    return tutoringMode;
+        if (student != null && student.getStudentModel() != null
+            && student.getStudentModel().getTutoringMode() != null) {
+            return student.getStudentModel().getTutoringMode();
+        }
+        return tutoringMode;
     }
 
     public void setTutoringMode(TutoringMode tutoringMode) {
         this.tutoringMode = tutoringMode;
+        if (student != null && student.getStudentModel() != null) {
+            student.getStudentModel().setTutoringMode(tutoringMode);
+        }
     }
     
     

--- a/src/main/java/edu/regis/shatu/view/EncodeView.java
+++ b/src/main/java/edu/regis/shatu/view/EncodeView.java
@@ -27,12 +27,14 @@ import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
 
 import edu.regis.shatu.model.StepCompletion;
+import edu.regis.shatu.model.TutoringSession;
 import edu.regis.shatu.model.aol.NewExampleRequest;
 import edu.regis.shatu.model.aol.ProblemType;
 import edu.regis.shatu.model.aol.StepSubType;
 import edu.regis.shatu.model.steps.EncodeAsciiStep;
 import edu.regis.shatu.model.steps.Step;
 import edu.regis.shatu.model.aol.TutoringMode;
+import edu.regis.shatu.model.aol.PendingTask;
 
 /**
  * A view that requests the student to add a single '1' bit to the byte prompt.
@@ -328,7 +330,21 @@ public class EncodeView extends UserRequestView {
 
             System.out.println("Encode ASCII update display called"); // Error checking
 
-            Step step = model.currentTask().getCurrentStep().getStep(); // Will be the last subtype a example was
+            PendingTask pTask = model.currentTask();
+            if (pTask == null || pTask.getCurrentStep() == null || pTask.getCurrentStep().getStep() == null) {
+                questionLabel.setText("Please click new example button to get started");
+                feedbackArea.setText("");
+                responseTextArea.setText("");
+                checkButton.setEnabled(false);
+                responseTextArea.setEnabled(false);
+                hintButton.setEnabled(false);
+
+                System.out.println("No current task/step loaded yet (currentTask was null).");
+                System.out.println("UpdateView logic continues...");
+                configureModeSpecificUI();
+                return;
+            }
+            Step step = pTask.getCurrentStep().getStep();
             // created for or empty
 
             System.out.println("Encode Ascii substep from current step: " + step.getSubType()); // Error checking
@@ -399,6 +415,27 @@ public class EncodeView extends UserRequestView {
         configureModeSpecificUI();
     }
 
+    @Override
+    public void setModel(TutoringSession model) {
+        super.setModel(model);
+
+        // Reset Encode view state when a new session model is loaded
+        this.question = null;
+        this.wasHintRequested = false;
+
+        messageLengthField.setText("1");
+        setQuestionField.setText("");
+
+        feedbackArea.setText("");
+        responseTextArea.setText("");
+
+        questionLabel.setText("Please click new example button to get started");
+
+        checkButton.setEnabled(false);
+        responseTextArea.setEnabled(false);
+        hintButton.setEnabled(false);
+    }
+    
     /**
      * Configure UI components based on the current tutoring mode
      * Disables fields not available for SEE_ONE mode for passive viewing.
@@ -415,9 +452,9 @@ public class EncodeView extends UserRequestView {
         TutoringMode mode = model.getTutoringMode();
 
         if (mode == TutoringMode.SEE_ONE) {
-            messageLengthField.setEnabled(false);
-            setQuestionField.setEnabled(false);
-            responseTextArea.setEnabled(false);
+            messageLengthField.setEnabled(true);
+            setQuestionField.setEnabled(true);
+            responseTextArea.setEnabled(true);
         } else {
             // DO_ONE and TEACH_ONE both have enabled the fields
             messageLengthField.setEnabled(true);

--- a/src/main/java/edu/regis/shatu/view/UserRequestView.java
+++ b/src/main/java/edu/regis/shatu/view/UserRequestView.java
@@ -129,7 +129,7 @@ public abstract class UserRequestView extends GPanel {
         if (mode == TutoringMode.SEE_ONE) {
             checkButton.setEnabled(false);
             hintButton.setEnabled(false);
-            newExampleButton.setEnabled(false);
+            newExampleButton.setEnabled(true);
         } else if (mode == TutoringMode.DO_ONE) {
             checkButton.setEnabled(true);
             hintButton.setEnabled(true);
@@ -151,8 +151,11 @@ public abstract class UserRequestView extends GPanel {
      * @param task 
      */
     public void setCurrentTask(PendingTask task) {
-       model.addCurrentTask(task);
-       updateView();
+       if (model == null) {
+            model = MainFrame.instance().getModel();
+        }
+        model.addCurrentTask(task);
+        updateView();
     }
     
       /**
@@ -255,7 +258,7 @@ public abstract class UserRequestView extends GPanel {
     } 
     
     
-    /*
+    
      public JButton getCheckButton() {
         return checkButton;
     }
@@ -268,5 +271,5 @@ public abstract class UserRequestView extends GPanel {
     public JButton getHintButton() {
         return hintButton;
     }
-    */
+    
 }


### PR DESCRIPTION
Got the new example button working for Encode ASCII. Message length and Set Own Question can be entered and correctly change the results of the new example press. 