### PR TITLE
Handling this.model null value for TutoringSession.setModel().

### DIFF
--- a/src/main/java/edu/regis/shatu/view/UserRequestView.java
+++ b/src/main/java/edu/regis/shatu/view/UserRequestView.java
@@ -109,6 +109,11 @@ public abstract class UserRequestView extends GPanel {
     }
     
     public void setModel(TutoringSession model) {
+        // SHAT-356: This should prevent model from causing a hang when 
+        // requesting New Example.
+        if (model == null) {
+            return;
+        }
         random = new Random();
         this.model = model;
         configureModeSpecificUI();


### PR DESCRIPTION
Repeated error for Jira https://chayabasha.atlassian.net/browse/SHAT-356 reporting that this.model was null. The application would hang after clicking on New Example. Added null pointer check to setModel().