### PR TITLE
SHAT-341 Fixed sign assessment loading

### DIFF
--- a/src/main/java/edu/regis/shatu/dao/SessionDAO.java
+++ b/src/main/java/edu/regis/shatu/dao/SessionDAO.java
@@ -37,10 +37,12 @@ import edu.regis.shatu.model.TutoringSession;
 import edu.regis.shatu.model.UnitDigest;
 import edu.regis.shatu.model.aol.PendingStep;
 import edu.regis.shatu.model.aol.PendingTask;
+import edu.regis.shatu.model.aol.StudentModel;
 import edu.regis.shatu.svc.CourseSvc;
 import edu.regis.shatu.svc.ProblemSvc;
 import edu.regis.shatu.svc.ServiceFactory;
 import edu.regis.shatu.svc.SessionSvc;
+import edu.regis.shatu.svc.StudentModelSvc;
 
 /**
  *
@@ -100,6 +102,86 @@ public class SessionDAO extends MySqlDAO implements SessionSvc, CRUD<TutoringSes
             close(conn, stmt);
         }
     }
+    
+    @Override
+    public TutoringSession retrieve(Account account) throws ObjNotFoundException, NonRecoverableException {
+               final String sql =
+                "SELECT Id, SecurityToken, IsActive, StartDate, CourseId, UnitId, ProblemId FROM TutoringSession WHERE UserId = ?";
+
+        Connection conn = null;
+        PreparedStatement stmt = null;
+        
+        String userId = account.getUserId();
+
+        try {
+            conn = DriverManager.getConnection(URL);
+            stmt = conn.prepareStatement(sql);
+
+            stmt.setString(1, userId);
+
+            ResultSet rs = stmt.executeQuery();
+
+            Student student = new Student(account);
+
+            if (rs.next()) {
+                TutoringSession session = new TutoringSession(student);
+                session.setId(rs.getInt(1));
+                session.setSecurityToken(rs.getString("SecurityToken"));
+                session.setIsActive(rs.getBoolean("IsActive"));
+
+                Timestamp timestamp = rs.getTimestamp("StartDate");
+                GregorianCalendar calendar = new GregorianCalendar();
+                calendar.setTimeInMillis(timestamp.getTime());
+                session.setStartDate(calendar);
+                
+                StudentModelSvc stuModSvc = ServiceFactory.findStudentModelSvc();
+                StudentModel studentModel = stuModSvc.retrieve(userId);
+                student.setStudentModel(studentModel);
+
+                int courseId = rs.getInt("CourseId");
+                int unitId = rs.getInt("UnitId");
+
+                CourseSvc courseSvc = ServiceFactory.findCourseSvc();
+                try {
+                    CourseDigest digest = courseSvc.retrieveDigest(courseId, conn);
+                    session.setCourse(digest);
+                } catch (ObjNotFoundException ex) {
+                    String errMsg = "SessionDAO-ERR-2 Course digest not found for courseId " + courseId;
+                    throw new NonRecoverableException(errMsg);
+                }
+
+                try {
+                    UnitDigest unitDigest = courseSvc.retrieveUnitDigest(courseId, unitId, conn);
+                    session.setUnit(unitDigest);
+
+                } catch (ObjNotFoundException ex) {
+                    String errMsg = "SessionDAO-ERR-3 Unit " + unitId + " not found in course " + courseId;
+                    throw new NonRecoverableException(errMsg);
+                }
+                
+                // Fetch the problem from the DB, if one exists for the session
+                ProblemSvc problemSvc = ServiceFactory.findProblemSvc();
+                int problemId = rs.getInt("ProblemId");
+                if (rs.wasNull()) {
+                    session.setProblem(null);
+                }
+                else {
+                    session.setProblem(problemSvc.retrieve(problemId));
+                }
+
+                session.setTasks(retrievePendingTasks(session, conn));
+
+                return session;
+
+            } else {
+                throw new ObjNotFoundException("Session not found for userId:" + userId);
+            }
+        } catch (SQLException e) {
+            throw new NonRecoverableException("SessionDAO-ERR-4" + e.toString(), e);
+        } finally {
+            close(conn, stmt);
+        }
+    }
 
     /**
      * {@inheritDoc}
@@ -126,10 +208,10 @@ public class SessionDAO extends MySqlDAO implements SessionSvc, CRUD<TutoringSes
             // object to make a student.
             AccountDAO accDao = new AccountDAO();
             Account acc = accDao.retrieve(userId);
-            Student stu = new Student(acc);
+            Student student = new Student(acc);
 
             if (rs.next()) {
-                TutoringSession session = new TutoringSession(stu);
+                TutoringSession session = new TutoringSession(student);
                 session.setId(rs.getInt(1));
                 session.setSecurityToken(rs.getString("SecurityToken"));
                 session.setIsActive(rs.getBoolean("IsActive"));
@@ -138,6 +220,10 @@ public class SessionDAO extends MySqlDAO implements SessionSvc, CRUD<TutoringSes
                 GregorianCalendar calendar = new GregorianCalendar();
                 calendar.setTimeInMillis(timestamp.getTime());
                 session.setStartDate(calendar);
+                
+                StudentModelSvc stuModSvc = ServiceFactory.findStudentModelSvc();
+                StudentModel studentModel = stuModSvc.retrieve(userId);
+                student.setStudentModel(studentModel);
 
                 int courseId = rs.getInt("CourseId");
                 int unitId = rs.getInt("UnitId");

--- a/src/main/java/edu/regis/shatu/svc/SessionSvc.java
+++ b/src/main/java/edu/regis/shatu/svc/SessionSvc.java
@@ -15,6 +15,7 @@ package edu.regis.shatu.svc;
 import edu.regis.shatu.dao.interfaces.CRUD;
 import edu.regis.shatu.err.NonRecoverableException;
 import edu.regis.shatu.err.ObjNotFoundException;
+import edu.regis.shatu.model.Account;
 import edu.regis.shatu.model.TutoringSession;
 
 /**
@@ -45,6 +46,16 @@ public interface SessionSvc extends CRUD<TutoringSession> {
     // */
     // TutoringSession retrieve(String student) throws ObjNotFoundException,
     // NonRecoverableException;
+    
+    /**
+     * Load from the DB and return the TutoringSession for the given account.
+     * 
+     * @param account
+     * @return TutoringSession for the given account user id.
+     * @throws ObjNotFoundException No session for the given account exists.
+     * @throws NonRecoverableException NonRecoverableException perhaps see getCause().getErrorCode().
+     */
+    TutoringSession retrieve(Account account) throws ObjNotFoundException, NonRecoverableException;
 
     /**
      * Return the security token (from the DB) for the given user id

--- a/src/main/java/edu/regis/shatu/svc/ShaTuTutor.java
+++ b/src/main/java/edu/regis/shatu/svc/ShaTuTutor.java
@@ -72,6 +72,7 @@ import static edu.regis.shatu.model.aol.TutoringMode.TEACH_ONE;
 import edu.regis.shatu.model.steps.Step;
 import edu.regis.shatu.model.steps.EncodeAsciiStep;
 import edu.regis.shatu.objectives.*;
+import java.util.HashMap;
 
 /**
  * The ShaTu tutor, which implements the tutoring service.
@@ -429,22 +430,16 @@ public class ShaTuTutor implements TutorSvc {
             Account dbAcct = ServiceFactory.findAccountSvc().retrieve(requestAcct.getUserId());
 
             if (dbAcct.getPassword().equals(requestAcct.getPassword())) {
-                student = new Student(dbAcct);
-                String userId = dbAcct.getUserId();
-
-                try {
-                    StudentModelSvc stuModSvc = ServiceFactory.findStudentModelSvc();
-                    studentModel = stuModSvc.retrieve(userId);
-                    student.setStudentModel(studentModel);
-                    notifyLogin(student);
-                } catch (ObjNotFoundException ex) {
-                    TutorReply reply = new TutorReply(":ERR");
-                    reply.setData("Student model not found for: " + userId);
-                    return reply;
-                }
+                //student = new Student(dbAcct);
+                String userId = dbAcct.getUserId();             
 
                 SessionSvc svc = ServiceFactory.findSessionSvc();
-                session = svc.retrieve(student.getAccount().getUserId());
+            
+                session = svc.retrieve(dbAcct);
+                
+                student = session.getStudent();
+                
+                notifyLogin(student);
 
                 TutorReply reply = new TutorReply("Authenticated");
 


### PR DESCRIPTION
The Tutor and Session DAO were both creating a student. Only the tutor's student had the assessments loaded. But the session's student was being returned to the GUI. Updated the SessionDAO to load the assessment data. Also cleaned up code associated with creating two student objects.