### PR TITLE
SHAT-371 fix sign out login history update query

### DIFF
--- a/src/main/java/edu/regis/shatu/dao/StudentModelDAO.java
+++ b/src/main/java/edu/regis/shatu/dao/StudentModelDAO.java
@@ -513,13 +513,13 @@ public void recordLoginEvent(String userId, long timestamp) throws NonRecoverabl
         // a new id this will not work and we should create our own monotonically
         // increasing session number.
         String updateLoginSql
-                = "UPDATE LoginHistory "
-                + "SET LogoutTime = ? "
-                + "WHERE UserId = ? AND SessionNumber = ("
-                + "    SELECT MAX(Id) FROM ("
-                + "        SELECT Id FROM LoginHistory WHERE UserId = ?"
-                + "    ) AS temp"
-                + ")";
+            = "UPDATE LoginHistory "
+            + "SET LogoutTime = ? "
+            + "WHERE Id = ("
+            + "    SELECT MAX(Id) FROM ("
+            + "        SELECT Id FROM LoginHistory WHERE UserId = ?"
+            + "    ) AS temp"
+            + ")";
         Timestamp tStamp = new Timestamp(timestamp);
 
         try (Connection conn = DriverManager.getConnection(URL)) {
@@ -532,7 +532,6 @@ public void recordLoginEvent(String userId, long timestamp) throws NonRecoverabl
             try (PreparedStatement updateLoginStmt = conn.prepareStatement(updateLoginSql)) {
                 updateLoginStmt.setTimestamp(1, tStamp);
                 updateLoginStmt.setString(2, userId);
-                updateLoginStmt.setString(3, userId);
                 updateLoginStmt.executeUpdate();
             }
         } catch (SQLException ex) {


### PR DESCRIPTION
Fixed sign-out failure caused by a schema/query mismatch in StudentModelDAO.recordLogoutEvent().

The logout query was attempting to update LoginHistory using SessionNumber, but the LoginHistory table does not contain that column. Updated the query to use the most recent LoginHistory Id for the current user instead.

Tested locally with a clean run:
- sign in succeeded
- sign out succeeded
- app returned to the sign-in page
- SIGN_OUT reply was returned correctly