### PR TITLE
SHAT-364 add developer mode setting

### DIFF
--- a/setup_ShaTuDB.sql
+++ b/setup_ShaTuDB.sql
@@ -1,3 +1,4 @@
+-- setup_ShaTuDB.sql
 -- SHATU: SHA-256 Tutor
 -- (C) Johanna & Richard Blumenthal, All rights reserved
 -- Unauthorized use, duplication or distribution without the authors' permission is strictly prohibited.
@@ -150,6 +151,12 @@ CREATE TABLE LoginHistory (
 CREATE TABLE StudentModel (
     UserId VARCHAR(255) NOT NULL PRIMARY KEY,
     ScaffoldLevel ENUM ('NONE', 'LOW', 'MEDIUM', 'HIGH', 'EXTREME')
+);
+
+CREATE TABLE DeveloperMode (
+    UserId VARCHAR(255) NOT NULL PRIMARY KEY,
+    IsEnabled TINYINT DEFAULT 0,
+    TutoringMode ENUM('SEE_ONE', 'DO_ONE', 'TEACH_ONE') DEFAULT 'SEE_ONE'
 );
 
 -- A static description of a task to complete within a course unit.
@@ -388,6 +395,11 @@ INSERT INTO Unit (Id, CourseId, Title,
     0, 'FIXED_SEQUENCE');
 
 /* ********** ADD FOREIGN KEY CONSTRAINTS ********** */
+ALTER TABLE DeveloperMode
+ADD CONSTRAINT fk_developermode_userid
+FOREIGN KEY (UserId) REFERENCES Account(UserId)
+ON UPDATE CASCADE ON DELETE CASCADE;
+
 
 ALTER Table Assessment
 ADD CONSTRAINT fk_assessment_userid

--- a/src/main/java/edu/regis/shatu/dao/DeveloperModeDAO.java
+++ b/src/main/java/edu/regis/shatu/dao/DeveloperModeDAO.java
@@ -1,0 +1,165 @@
+
+/**
+ * Data access object for the DeveloperMode table.
+ *
+ * This DAO supports SHAT-364 developer mode behavior. Developer mode lets a
+ * developer control which TutoringMode a user should enter after sign in
+ * without recompiling the application or hardcoding test values in Java.
+ *
+ * The DeveloperMode table stores one optional row per user. If no row exists,
+ * or if developer mode is disabled, the application should continue using the
+ * normal tutoring mode already loaded with the session.
+ */
+
+package edu.regis.shatu.dao;
+
+import edu.regis.shatu.err.NonRecoverableException;
+import edu.regis.shatu.model.aol.TutoringMode;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class DeveloperModeDAO extends MySqlDAO {
+
+    /**
+     * Data access object for the DeveloperMode table.
+     *
+     * Developer mode lets developers choose a tutoring mode from the database
+     * without recompiling or hardcoding test values. This class also verifies
+     * that the DeveloperMode table exists before reading from it, so older local
+     * databases do not break after pulling SHAT-364.
+     */
+    public DeveloperModeDAO() {
+        super("DeveloperMode", "UserId");
+    }
+
+    /**
+     * Retrieves the developer-selected tutoring mode for a user.
+     *
+     * If the DeveloperMode table is missing, this method creates it. If the
+     * user has no row, developer mode is disabled, or the stored mode is blank,
+     * this method returns null so normal login behavior continues.
+     *
+     * @param userId the account user id
+     * @return selected TutoringMode, or null if no override should be applied
+     * @throws NonRecoverableException if schema setup or retrieval fails
+     */
+    public TutoringMode retrieveTutoringMode(String userId) throws NonRecoverableException {
+        ensureDeveloperModeTable();
+        
+        ensureUserDeveloperModeRow(userId);
+        
+        String sql = "SELECT IsEnabled, TutoringMode FROM DeveloperMode WHERE UserId = ?";
+
+        try (Connection conn = DriverManager.getConnection(URL);
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+
+            stmt.setString(1, userId);
+
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (!rs.next()) {
+                    return null;
+                }
+
+                boolean isEnabled = rs.getInt("IsEnabled") == 1;
+                if (!isEnabled) {
+                    return null;
+                }
+
+                String mode = rs.getString("TutoringMode");
+                if (mode == null || mode.isEmpty()) {
+                    return null;
+                }
+
+                return TutoringMode.valueOf(mode);
+            }
+
+        } catch (SQLException ex) {
+            throw new NonRecoverableException("Error retrieving developer mode: " + ex.toString(), ex);
+        } catch (IllegalArgumentException ex) {
+            throw new NonRecoverableException("Invalid developer tutoring mode for user: " + userId, ex);
+        }
+    }
+
+    /**
+     * Creates the DeveloperMode table if it is missing.
+     *
+     * This keeps older local databases compatible after developers pull the
+     * SHAT-364 changes. The setup_ShaTuDB.sql file still contains the official
+     * schema, but this method prevents runtime errors when the local database
+     * has not been rebuilt.
+     *
+     * @throws NonRecoverableException if the table cannot be created
+     */
+    private void ensureDeveloperModeTable() throws NonRecoverableException {
+        String createTableSql
+                = "CREATE TABLE IF NOT EXISTS DeveloperMode ("
+                + "UserId VARCHAR(255) NOT NULL PRIMARY KEY, "
+                + "IsEnabled TINYINT DEFAULT 0, "
+                + "TutoringMode ENUM('SEE_ONE', 'DO_ONE', 'TEACH_ONE') DEFAULT 'SEE_ONE'"
+                + ")";
+
+        try (Connection conn = DriverManager.getConnection(URL);
+             PreparedStatement stmt = conn.prepareStatement(createTableSql)) {
+
+            stmt.executeUpdate();
+
+        } catch (SQLException ex) {
+            throw new NonRecoverableException("Error creating DeveloperMode table: " + ex.toString(), ex);
+        }
+    }
+    
+    
+    /**
+    * Creates a default DeveloperMode row for the user if one does not already
+    * exist.
+    *
+    * The default keeps developer mode disabled so normal users are not affected.
+    * A developer can later enable the row and choose SEE_ONE, DO_ONE, or TEACH_ONE.
+    *
+    * @param userId the account user id
+    * @throws NonRecoverableException if the default row cannot be created
+    */
+   private void ensureUserDeveloperModeRow(String userId) throws NonRecoverableException {
+       String sql
+               = "INSERT IGNORE INTO DeveloperMode "
+               + "(UserId, IsEnabled, TutoringMode) "
+               + "VALUES (?, 0, 'SEE_ONE')";
+
+       try (Connection conn = DriverManager.getConnection(URL);
+            PreparedStatement stmt = conn.prepareStatement(sql)) {
+
+           stmt.setString(1, userId);
+           stmt.executeUpdate();
+
+       } catch (SQLException ex) {
+           throw new NonRecoverableException("Error creating default developer mode row: " + ex.toString(), ex);
+       }
+   }
+
+    public void updateDeveloperMode(String userId, boolean isEnabled, TutoringMode mode) throws NonRecoverableException {
+        ensureDeveloperModeTable();
+        ensureUserDeveloperModeRow(userId);
+
+        String sql
+                = "UPDATE DeveloperMode "
+                + "SET IsEnabled = ?, TutoringMode = ? "
+                + "WHERE UserId = ?";
+
+        try (Connection conn = DriverManager.getConnection(URL);
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+
+            stmt.setInt(1, isEnabled ? 1 : 0);
+            stmt.setString(2, mode.name());
+            stmt.setString(3, userId);
+            stmt.executeUpdate();
+
+        } catch (SQLException ex) {
+            throw new NonRecoverableException("Error updating developer mode: " + ex.toString(), ex);
+        }
+    }
+   
+   
+}

--- a/src/main/java/edu/regis/shatu/svc/ShaTuTutor.java
+++ b/src/main/java/edu/regis/shatu/svc/ShaTuTutor.java
@@ -24,6 +24,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import edu.regis.shatu.dao.SessionDAO;
+import edu.regis.shatu.dao.DeveloperModeDAO;
 import edu.regis.shatu.err.NonRecoverableException;
 import edu.regis.shatu.err.ObjDuplicateException;
 import edu.regis.shatu.err.ObjNotFoundException;
@@ -36,7 +37,6 @@ import edu.regis.shatu.model.Student;
 import edu.regis.shatu.model.Task;
 import edu.regis.shatu.model.TutoringSession;
 import edu.regis.shatu.model.Unit;
-import edu.regis.shatu.model.aol.StudentModel;
 import edu.regis.shatu.model.StudentModelFieldKind;
 import edu.regis.shatu.model.aol.Assessment;
 import edu.regis.shatu.model.aol.AssessmentLevel;
@@ -416,6 +416,34 @@ public class ShaTuTutor implements TutorSvc {
         }
     }
 
+    
+    
+
+
+
+    private void applyDeveloperModeOverride(String userId) {
+        try {
+            DeveloperModeDAO dao = new DeveloperModeDAO();
+            TutoringMode mode = dao.retrieveTutoringMode(userId);
+
+            if (mode == null) {
+                System.out.println("[ShaTuTutor.java] - [DeveloperMode] - no override for userId=" + userId);
+                return;
+            }
+
+            session.setTutoringMode(mode);
+
+            System.out.println("[ShaTuTutor.java] - [DeveloperMode] - tutoringMode override applied=" + mode);
+
+        } catch (NonRecoverableException ex) {
+            Logger.getLogger(ShaTuTutor.class.getName()).log(
+                    Level.WARNING,
+                    "Developer mode override failed. Login will continue normally.",
+                    ex
+            );
+        }
+    }
+    
     /**
      * Attempts to sign a student in.
      *
@@ -463,8 +491,9 @@ public class ShaTuTutor implements TutorSvc {
                 System.out.println("signIn problem task count=" + session.getProblem().getTasks().size());
 
                 student = session.getStudent();
-
-
+                
+                applyDeveloperModeOverride(userId);
+                
             // Do not let login history problems block a successful login
             try {
                 notifyLogin(student);

--- a/src/main/java/edu/regis/shatu/view/DashboardPanel.java
+++ b/src/main/java/edu/regis/shatu/view/DashboardPanel.java
@@ -28,6 +28,12 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+
+import edu.regis.shatu.dao.DeveloperModeDAO;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+
+
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
@@ -208,6 +214,8 @@ public class DashboardPanel extends JPanel {
 
         settingsButton.setVerticalAlignment(SwingConstants.TOP);
 
+        settingsButton.addActionListener(evt -> showDeveloperModeSettings());
+        
         // Let tutor control, navigate directly to TUTOR view
         seeOneButton.addActionListener(evt -> {
             if (model != null) {
@@ -963,4 +971,75 @@ public class DashboardPanel extends JPanel {
             MainFrame.instance().displayStep(selection);
         }
     }
+
+    private void showDeveloperModeSettings() {
+        if (model == null || model.getStudent() == null || model.getStudent().getAccount() == null) {
+            JOptionPane.showMessageDialog(this,
+                    "Please sign in before changing settings.",
+                    "Settings",
+                    JOptionPane.INFORMATION_MESSAGE);
+            return;
+        }
+
+        String userId = model.getStudent().getAccount().getUserId();
+
+        JCheckBox enableDeveloperMode = new JCheckBox("Enable developer mode");
+        JComboBox<TutoringMode> modeBox = new JComboBox<>(TutoringMode.values());
+
+        modeBox.setSelectedItem(model.getStudent().getStudentModel().getTutoringMode());
+
+        JPanel panel = new JPanel(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(5, 5, 5, 5);
+        gbc.anchor = GridBagConstraints.WEST;
+
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        panel.add(enableDeveloperMode, gbc);
+
+        gbc.gridy = 1;
+        panel.add(new JLabel("Tutoring mode:"), gbc);
+
+        gbc.gridx = 1;
+        panel.add(modeBox, gbc);
+
+        int result = JOptionPane.showConfirmDialog(
+                this,
+                panel,
+                "Developer Mode Settings",
+                JOptionPane.OK_CANCEL_OPTION,
+                JOptionPane.PLAIN_MESSAGE
+        );
+
+        if (result != JOptionPane.OK_OPTION) {
+            return;
+        }
+
+        try {
+            TutoringMode selectedMode = (TutoringMode) modeBox.getSelectedItem();
+            DeveloperModeDAO dao = new DeveloperModeDAO();
+
+            dao.updateDeveloperMode(userId, enableDeveloperMode.isSelected(), selectedMode);
+
+            if (enableDeveloperMode.isSelected()) {
+                model.setTutoringMode(selectedMode);
+                MainFrame.instance().setModel(model);
+                rebuildDashboard();
+                updateAllProgressBars();
+            }
+
+            JOptionPane.showMessageDialog(this,
+                    "Developer mode settings saved. Sign in again to test the full login override.",
+                    "Settings Saved",
+                    JOptionPane.INFORMATION_MESSAGE);
+
+        } catch (NonRecoverableException ex) {
+            JOptionPane.showMessageDialog(this,
+                    "Could not save developer mode settings.",
+                    "Settings Error",
+                    JOptionPane.ERROR_MESSAGE);
+        }
+    }
+    
+    
 }


### PR DESCRIPTION
Summary
Adds a developer mode that allows overriding the tutoring mode at login for testing purposes.

Changes
- added DeveloperMode table to setup_ShaTuDB.sql
- created DeveloperModeDAO for retrieving developer settings
- integrated developer mode override into ShaTuTutor during sign-in
- updated DashboardPanel to reflect overridden tutoring mode
- verified behavior through logs and UI updates

Behavior
- if developer mode is not set, system behaves normally
- if developer mode is enabled, tutoring mode is overridden on login
- override is visible in dashboard and persists through session

Testing
- verified sign-in flow applies override correctly
- confirmed dashboard updates to SEE_ONE, DO_ONE, TEACH_ONE
- confirmed no impact to normal users without developer mode

Notes
This is intended for development and testing only and does not affect production behavior unless explicitly enabled in the database.